### PR TITLE
Adding a task to autofix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1140,6 +1140,12 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "cheerio": {
       "version": "1.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
@@ -1493,6 +1499,12 @@
       "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
       "dev": true
     },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -1552,6 +1564,12 @@
           }
         }
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -7750,6 +7768,17 @@
       "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
       "dev": true
     },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
     "mdn-data": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
@@ -10496,6 +10525,27 @@
         }
       }
     },
+    "raven": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.3.tgz",
+      "integrity": "sha512-bKre7qlDW+y1+G2bUtCuntdDYc8o5v1T233t0vmJfbj8ttGOgLrGRlYB8saelVMW9KUAJNLrhFkAKOwFWFJonw==",
+      "dev": true,
+      "requires": {
+        "cookie": "0.3.1",
+        "md5": "^2.2.1",
+        "stack-trace": "0.0.10",
+        "timed-out": "4.0.1",
+        "uuid": "3.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
+          "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg=",
+          "dev": true
+        }
+      }
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -11209,6 +11259,21 @@
             "minimatch": "~3.0.2"
           }
         }
+      }
+    },
+    "sass-lint-auto-fix": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/sass-lint-auto-fix/-/sass-lint-auto-fix-0.11.3.tgz",
+      "integrity": "sha512-RuiZnFr6DRMcIX+IEHBg/OY2rBB1OnadQNpML1YD0AApi5S5BjZpZKRE/BDlwgy67Bbhs8U1MY8HJgI5YlNQLA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.2",
+        "commander": "^2.15.1",
+        "glob": "^7.1.2",
+        "gonzales-pe-sl": "^4.2.3",
+        "js-yaml": "^3.11.0",
+        "raven": "^2.6.2",
+        "sass-lint": "^1.12.1"
       }
     },
     "sassdoc": {
@@ -12029,6 +12094,12 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
     "stack-utils": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build:package": "gulp build:package --destination 'package' && npm run test:build:package",
     "build:dist": "gulp build:dist --destination 'dist' && npm run test:build:dist",
     "test": "standard && gulp test && gulp copy-assets && jest --testPathIgnorePatterns='after-*'",
+    "test:autofix": "standard --fix && sass-lint-auto-fix",
     "test:build:package": "jest tasks/gulp/__tests__/after-build-package.test.js",
     "test:build:dist": "jest tasks/gulp/__tests__/after-build-dist.test.js"
   },
@@ -50,6 +51,7 @@
     "postcss-scss": "^2.0.0",
     "recursive-readdir": "^2.2.2",
     "run-sequence": "^2.2.1",
+    "sass-lint-auto-fix": "^0.11.3",
     "sassdoc": "^2.5.0",
     "standard": "^11.0.1",
     "vinyl-paths": "^2.1.0",

--- a/src/components/notification-badge/_notification-badge.scss
+++ b/src/components/notification-badge/_notification-badge.scss
@@ -1,12 +1,12 @@
 .hmrc-notification-badge {
-  display: inline-block;
-  min-width: 10px;
-  padding: 5px 8px 1px 8px;
-  border-radius: 10px;
-  color: govuk-colour("white");
   background: govuk-colour("red");
+  border-radius: 10px;
+  min-width: 10px;
+  color: govuk-colour("white");
+  display: inline-block;
   font-size: 14px;
   font-weight: 600;
+  padding: 5px 8px 1px 8px;
   text-align: center;
   white-space: nowrap;
 }


### PR DESCRIPTION
Autofix exists for `standard` out of the box and there's a module for autofixing `sass-lint`.  This makes both of those available under the command:

```
npm run test:autofix
```