### PR TITLE
Add src dir to /assets route for component images

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -45,7 +45,7 @@ module.exports = (options) => {
 
   // serve html5-shiv from node modules
   app.use('/vendor/html5-shiv/', express.static('node_modules/html5shiv/dist/'))
-  app.use('/assets', express.static(path.join(configPaths.src, 'assets')))
+  app.use('/assets', express.static(path.join(configPaths.src)))
 
   // Define routes
 

--- a/app/assets/scss/app.scss
+++ b/app/assets/scss/app.scss
@@ -2,5 +2,6 @@
 // right corner of your site during development, add the breakpoints
 // to this list, ordered by width, e.g. (mobile, tablet, desktop).
 $mq-show-breakpoints: (mobile, tablet, desktop);
+
 @import "../../../src/all";
 @import "partials/app";


### PR DESCRIPTION
The `$hmrc-assets-path` SCSS variable was already being [defaulted to `/assets/` in `all.scss`](https://github.com/hmrc/hmrc-frontend/blob/e5336c9b9b7b9bf54af3b16e77c532eb4f908552/src/all.scss#L12) but the puppeteer app was hosting a non-existent `/src/assets` directory at that route.

Just needed to host `/src` at that route instead to get all our component image paths working.

## Notes

There's a follow piece of work needed to review how we cache-bust these file paths as part of our versioning strategy. They come out in the compiled CSS as `/assets/components/account-menu/images/icon-chevron-left.svg` but we either need to hash the filename or version the path.