### PR TITLE
SDT-983 fix LDS false positives

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 leakDetectionExemptions:
-  - ruleId: 'ip_addresses'
-    filepaths:
-      - '/src/layouts/layout-account-header.htmls'
+ - ruleId: 'ip_addresses'
+   filepaths:
+    - '/src/layouts/layout-account-header.html'

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 leakDetectionExemptions:
  - ruleId: 'ip_addresses'
-   filepaths:
+   filePaths:
     - '/src/layouts/layout-account-header.html'

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,4 @@
+leakDetectionExemptions:
+  - ruleId: 'ip_addresses'
+    filepaths:
+      - '/src/layouts/layout-account-header.htmls'


### PR DESCRIPTION
Mark the layout-account-header.html file as ignored for the IP Address rule in LDS, due to the SVG data generating a false positive.