### PR TITLE
Fix failing uglify in build tasks

### DIFF
--- a/src/components/account-menu/account-menu.js
+++ b/src/components/account-menu/account-menu.js
@@ -180,8 +180,8 @@ function initAccountMenu (global, HMRC) {
 
       // TODO: modernise the following and polyfill it for IE8
       var $elementSiblings = element.parentNode.parentNode.children
-      for (let i = 0; i < $elementSiblings.length; i++) {
-        const sibling = $elementSiblings[i]
+      for (var i = 0; i < $elementSiblings.length; i++) {
+        var sibling = $elementSiblings[i]
         if (sibling !== $backLink.parentNode && sibling !== element.parentNode) {
           sibling.classList.add('hidden')
         }
@@ -211,8 +211,8 @@ function initAccountMenu (global, HMRC) {
 
       // TODO: modernise the following and polyfill it for IE8
       var $backLinkSiblings = $backLink.parentNode.parentNode.children
-      for (let i = 0; i < $backLinkSiblings.length; i++) {
-        const sibling = $backLinkSiblings[i]
+      for (var i = 0; i < $backLinkSiblings.length; i++) {
+        var sibling = $backLinkSiblings[i]
         if (sibling !== $backLink.parentNode) {
           sibling.classList.remove('hidden')
         }


### PR DESCRIPTION
`npm run build:dist` was failing because `let` and `const` are not being transpiled by rollup. uglify doesn't understand these keywords and so throws an error.

simplest solution for now is to just use `var` instead.

we might want to discuss how modern the JS we should be writing is, and whether we should rely on rollup/babel to transpile it for older browsers for us. that's a conversation that'll need input from other departments to make sure we're all writing to the same standards.