### PR TITLE
Refactor js to align with govuk-frontend

### DIFF
--- a/app/views/layouts/_generic.njk
+++ b/app/views/layouts/_generic.njk
@@ -28,7 +28,10 @@
 {% block bodyEnd %}
   <script src="/govuk-frontend/all.js"></script>
   <script src="/public/all.js"></script>
-  <script>window.GOVUKFrontend.initAll()</script>
+  <script>
+    window.GOVUKFrontend.initAll()
+    window.HMRCFrontend.initAll()
+  </script>
 
   {% block scripts %}{% endblock %}
 {% endblock %}

--- a/src/all.js
+++ b/src/all.js
@@ -1,7 +1,12 @@
-import initAccountMenu from './components/hmrc-account-menu/account-menu'
+import AccountMenu from './components/hmrc-account-menu/account-menu'
 
-window.HMRC = window.HMRC || {}
+function initAll () {
+  if (document.querySelector('[data-module="hmrc-account-menu"]')) {
+    new AccountMenu('[data-module="hmrc-account-menu"]').init()
+  }
+}
 
-if (document.querySelector('[data-module="hmrc-account-menu"]')) {
-  initAccountMenu(window, window.HMRC)
+export {
+  initAll,
+  AccountMenu
 }

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,0 +1,25 @@
+// Returns a function, that, as long as it continues to be invoked, will not
+// be triggered. The function will be called after it stops being called for
+// N milliseconds. If `immediate` is passed, trigger the function on the
+// leading edge, instead of the trailing.
+export function debounce (func, wait, immediate) {
+  var timeout
+
+  return function () {
+    var context = this
+    var args = arguments
+
+    var later = function () {
+      timeout = null
+      if (!immediate) func.apply(context, args)
+    }
+
+    var callNow = immediate && !timeout
+
+    clearTimeout(timeout)
+
+    timeout = setTimeout(later, wait)
+
+    if (callNow) func.apply(context, args)
+  }
+}


### PR DESCRIPTION
Our javascript is self-initialising and structured as it was in the now legacy assets-frontend.

Adopting [the "govuk-frontend way" of structuring javascript](https://github.com/alphagov/govuk-frontend/blob/master/docs/contributing/coding-standards/js.md#skeleton) gives us a more consistent developer experience for both contributors and consumers. It'll also make contributing components with JS to govuk-frontend much easier in the future.