### PR TITLE
SDT-1023 Fix spacing of Account Menu on IE9 to IE11

### DIFF
--- a/src/components/hmrc-account-menu/_account-menu.scss
+++ b/src/components/hmrc-account-menu/_account-menu.scss
@@ -385,7 +385,7 @@ hmrc-subnav__section__heading {
   }
 }
 
-.js-enabled .hmrc-hmrc-account-menu__link--more {
+.js-enabled .hmrc-account-menu__link--more {
   position: relative;
   padding-right: 31px;
   border-bottom: 0;

--- a/src/components/hmrc-account-menu/_account-menu.scss
+++ b/src/components/hmrc-account-menu/_account-menu.scss
@@ -153,12 +153,11 @@ $hmrc-transition-type: "all";
 
 .hmrc-account-menu__main {
   z-index: 995;
-  margin: initial;
+  margin: 0;
   float: right;
 
   li {
     display: inline-block;
-    margin: initial;
     margin-bottom: 0;
   }
 }


### PR DESCRIPTION
IE before version 12 didn't support the `initial` css value

## Before
![screenshot from 2019-02-12 12-25-11](https://user-images.githubusercontent.com/234825/52635333-81a2b280-2ec1-11e9-8ee1-c3d7a004350d.png)

## After
![screenshot from 2019-02-12 12-26-46](https://user-images.githubusercontent.com/234825/52635339-88312a00-2ec1-11e9-945f-95ee78bef260.png)

