### PR TITLE
Removing legacy safety-check

### DIFF
--- a/src/_prototype-kit.scss
+++ b/src/_prototype-kit.scss
@@ -1,5 +1,3 @@
-$govuk-extensions-url-context: "/extension-assets" !default;
-
 $hmrc-assets-path: $govuk-extensions-url-context + "/hmrc-frontend/";
 
 @import "all";


### PR DESCRIPTION
This safety-check was introduced to keep backwards compatibility in the examples, now that the extensions are part of gouvk-prototype-kit and this variable is part of the contract/interface it is unnecessary. 

I'd like to be able to point people to this file as an example for them to follow, I think that example is best without the safety-check.