### PR TITLE
Building a dist without all of govuk.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,6 +102,7 @@ gulp.task('build:dist', cb => {
   runsequence(
     'clean',
     'copy-assets',
+    'copy-dist-files',
     'copy:assets',
     'update-assets-version',
     cb

--- a/src/all.scss
+++ b/src/all.scss
@@ -9,6 +9,8 @@ $govuk-global-styles: true;
 /// @type String
 /// @access public
 
-$hmrc-assets-path: "/assets/" !default;
+$hmrc-assets-path: "./" !default;
+$govuk-assets-path: $hmrc-assets-path !default;
+$govuk-is-ie8: false !default;
 
 @import "components/all";

--- a/src/components/hmrc-account-menu/_account-menu.scss
+++ b/src/components/hmrc-account-menu/_account-menu.scss
@@ -1,17 +1,8 @@
 
 $govuk-is-ie8: false !default;
-@import "node_modules/govuk-frontend/settings/media-queries";
-@import "node_modules/govuk-frontend/settings/colours-applied";
-@import "node_modules/govuk-frontend/settings/typography-font-families";
-@import "node_modules/govuk-frontend/settings/typography-font";
-@import "node_modules/govuk-frontend/settings/typography-responsive";
-@import "node_modules/govuk-frontend/settings/assets";
-@import "node_modules/govuk-frontend/tools/font-url";
-@import "node_modules/govuk-frontend/tools/ie8";
-@import "node_modules/govuk-frontend/helpers/clearfix";
-@import "node_modules/govuk-frontend/helpers/typography";
-@import "node_modules/govuk-frontend/helpers/font-faces";
-@import "node_modules/govuk-frontend/helpers/media-queries";
+@import "node_modules/govuk-frontend/settings/all";
+@import "node_modules/govuk-frontend/tools/all";
+@import "node_modules/govuk-frontend/helpers/all";
 @import "node_modules/govuk-frontend/vendor/sass-mq";
 
 // previously provided by govuk-template, no equivalent in govuk-frontend

--- a/src/components/hmrc-account-menu/_account-menu.scss
+++ b/src/components/hmrc-account-menu/_account-menu.scss
@@ -1,4 +1,18 @@
-@import "node_modules/govuk-frontend/all";
+
+$govuk-is-ie8: false !default;
+@import "node_modules/govuk-frontend/settings/media-queries";
+@import "node_modules/govuk-frontend/settings/colours-applied";
+@import "node_modules/govuk-frontend/settings/typography-font-families";
+@import "node_modules/govuk-frontend/settings/typography-font";
+@import "node_modules/govuk-frontend/settings/typography-responsive";
+@import "node_modules/govuk-frontend/settings/assets";
+@import "node_modules/govuk-frontend/tools/font-url";
+@import "node_modules/govuk-frontend/tools/ie8";
+@import "node_modules/govuk-frontend/helpers/clearfix";
+@import "node_modules/govuk-frontend/helpers/typography";
+@import "node_modules/govuk-frontend/helpers/font-faces";
+@import "node_modules/govuk-frontend/helpers/media-queries";
+@import "node_modules/govuk-frontend/vendor/sass-mq";
 
 // previously provided by govuk-template, no equivalent in govuk-frontend
 .hidden {
@@ -244,8 +258,6 @@ $hmrc-transition-type: "all";
 }
 
 .hmrc-subnav {
-  @include govuk-font(16);
-  @include govuk-clearfix;
   display: none;
   position: absolute;
   z-index: -1;
@@ -257,9 +269,6 @@ $hmrc-transition-type: "all";
   outline: none;
   background-color: govuk-colour("grey-4");
 
-  p {
-    @include govuk-font(16);
-  }
 
   a {
     text-decoration: none;
@@ -349,7 +358,6 @@ $hmrc-transition-type: "all";
 }
 
 hmrc-subnav__section__heading {
-  @include govuk-font(16, $weight: bold);
   margin: 0;
   padding-bottom: 5px;
   font-weight: 400;

--- a/src/components/hmrc-account-menu/_account-menu.scss
+++ b/src/components/hmrc-account-menu/_account-menu.scss
@@ -1,5 +1,3 @@
-
-$govuk-is-ie8: false !default;
 @import "node_modules/govuk-frontend/settings/all";
 @import "node_modules/govuk-frontend/tools/all";
 @import "node_modules/govuk-frontend/helpers/all";

--- a/src/components/hmrc-account-menu/_account-menu.scss
+++ b/src/components/hmrc-account-menu/_account-menu.scss
@@ -258,6 +258,8 @@ $hmrc-transition-type: "all";
 }
 
 .hmrc-subnav {
+  @include govuk-font(16);
+  @include govuk-clearfix;
   display: none;
   position: absolute;
   z-index: -1;
@@ -269,6 +271,9 @@ $hmrc-transition-type: "all";
   outline: none;
   background-color: govuk-colour("grey-4");
 
+  p {
+    @include govuk-font(16);
+  }
 
   a {
     text-decoration: none;
@@ -358,6 +363,7 @@ $hmrc-transition-type: "all";
 }
 
 hmrc-subnav__section__heading {
+  @include govuk-font(16, $weight: bold);
   margin: 0;
   padding-bottom: 5px;
   font-weight: 400;

--- a/src/dist.scss
+++ b/src/dist.scss
@@ -1,0 +1,4 @@
+$hmrc-assets-path: "./";
+$govuk-assets-path: "./";
+
+@import "all";

--- a/src/dist.scss
+++ b/src/dist.scss
@@ -1,4 +1,0 @@
-$hmrc-assets-path: "./";
-$govuk-assets-path: "./";
-
-@import "all";

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -31,11 +31,11 @@ const errorHandler = function (error) {
   this.emit('end')
 }
 // different entry points for both streams below and depending on destination flag
-const compileStyleshet = isDist ? configPaths.src + 'all.scss' : configPaths.app + 'assets/scss/app.scss'
-const compileOldIeStyleshet = isDist ? configPaths.src + 'all-ie8.scss' : configPaths.app + 'assets/scss/app-ie8.scss'
+const compileStylesheet = isDist ? configPaths.src + 'dist.scss' : configPaths.app + 'assets/scss/app.scss'
+const compileOldIeStylesheet = isDist ? configPaths.src + 'all-ie8.scss' : configPaths.app + 'assets/scss/app-ie8.scss'
 
 gulp.task('scss:compile', () => {
-  let compile = gulp.src(compileStyleshet)
+  let compile = gulp.src(compileStylesheet)
     .pipe(plumber(errorHandler))
     .pipe(sass())
     // minify css add vendor prefixes and normalize to compiled css
@@ -57,7 +57,7 @@ gulp.task('scss:compile', () => {
     ))
     .pipe(gulp.dest(taskArguments.destination + '/'))
 
-  let compileOldIe = gulp.src(compileOldIeStyleshet)
+  let compileOldIe = gulp.src(compileOldIeStylesheet)
     .pipe(plumber(errorHandler))
     .pipe(sass())
     // minify css add vendor prefixes and normalize to compiled css

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -31,7 +31,7 @@ const errorHandler = function (error) {
   this.emit('end')
 }
 // different entry points for both streams below and depending on destination flag
-const compileStylesheet = isDist ? configPaths.src + 'dist.scss' : configPaths.app + 'assets/scss/app.scss'
+const compileStylesheet = isDist ? configPaths.src + 'all.scss' : configPaths.app + 'assets/scss/app.scss'
 const compileOldIeStylesheet = isDist ? configPaths.src + 'all-ie8.scss' : configPaths.app + 'assets/scss/app-ie8.scss'
 
 gulp.task('scss:compile', () => {

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -28,3 +28,19 @@ gulp.task('copy-files', () => {
     .pipe(scssFiles.restore)
     .pipe(gulp.dest(taskArguments.destination + '/'))
 })
+
+gulp.task('copy-dist-files', ['copy-dist-component-files', 'copy-dist-fonts'])
+
+gulp.task('copy-dist-component-files', () => {
+  return gulp.src([
+    configPaths.src + '{components,needs-to-be-a-glob-to-preserve-directories}/hmrc-account-menu/images/*'
+  ])
+    .pipe(gulp.dest(taskArguments.destination + '/'))
+})
+
+gulp.task('copy-dist-fonts', () => {
+  return gulp.src([
+    'node_modules/govuk-frontend/assets/fonts/*'
+  ])
+    .pipe(gulp.dest(taskArguments.destination + '/fonts'))
+})


### PR DESCRIPTION
We're using some features from GOVUK's SCSS, we were previously including everything of theirs which included their styles in our generated markup.  We want to use their functions to generate our markup but not include their markup in our generated bundle.

This change focuses on bringing in the required features of GOVUK's SCSS rather than all of it.