### PR TITLE
Polyfill the account menu to support legacy browsers

### DIFF
--- a/app/views/layouts/layout-preview.njk
+++ b/app/views/layouts/layout-preview.njk
@@ -1,5 +1,19 @@
 {% extends previewLayout + ".njk" %}
 
+{% block head %}
+  <!--[if !IE 8]><!-->
+    <link rel="stylesheet" href="/public/app.css">
+  <!--<![endif]-->
+  <!--[if IE 8]>
+    <link rel="stylesheet" href="/public/app-ie8.css">
+  <![endif]-->
+  <!--[if lt IE 9]>
+    <script src="/vendor/html5-shiv/html5shiv.js"></script>
+  <![endif]-->
+
+  {% block styles %}{% endblock %}
+{% endblock %}
+
 {% set bodyClasses %}
  {{ bodyClasses }}
 {% endset %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2775,6 +2775,12 @@
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
+    "estree-walker": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+      "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -3497,7 +3503,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3518,12 +3525,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3538,17 +3547,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3665,7 +3677,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3677,6 +3690,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3691,6 +3705,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3698,12 +3713,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3722,6 +3739,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3802,7 +3820,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3814,6 +3833,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3899,7 +3919,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3935,6 +3956,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3954,6 +3976,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3997,12 +4020,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5692,6 +5717,12 @@
         "global-dirs": "^0.1.0",
         "is-path-inside": "^1.0.0"
       }
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
@@ -7874,6 +7905,15 @@
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
+    "magic-string": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -8456,7 +8496,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -8477,12 +8518,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8497,17 +8540,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8624,7 +8670,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8636,6 +8683,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8650,6 +8698,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -8657,12 +8706,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8681,6 +8732,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8761,7 +8813,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8773,6 +8826,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8858,7 +8912,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8894,6 +8949,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8913,6 +8969,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8956,12 +9013,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -11595,6 +11654,75 @@
         "@types/node": "*"
       }
     },
+    "rollup-plugin-commonjs": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.2.1.tgz",
+      "integrity": "sha512-X0A/Cp/t+zbONFinBhiTZrfuUaVwRIp4xsbKq/2ohA2CDULa/7ONSJTelqxon+Vds2R2t2qJTqJQucKUC8GKkw==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.5.2",
+        "magic-string": "^0.25.1",
+        "resolve": "^1.10.0",
+        "rollup-pluginutils": "^2.3.3"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "rollup-plugin-node-resolve": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.1.tgz",
+      "integrity": "sha512-fSS7YDuCe0gYqKsr5OvxMloeZYUSgN43Ypi1WeRZzQcWtHgFayV5tUSPYpxuaioIIWaBXl6NrVk0T2/sKwueLg==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.0.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.10.0"
+      },
+      "dependencies": {
+        "builtin-modules": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.0.0.tgz",
+          "integrity": "sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.4.1.tgz",
+      "integrity": "sha512-wesMQ9/172IJDIW/lYWm0vW0LiKe5Ekjws481R7z9WTRtmO59cqyM/2uUlxvf6yzm/fElFmHUobeQOYz46dZJw==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.0",
+        "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
+          "integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==",
+          "dev": true
+        }
+      }
+    },
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
@@ -12661,6 +12789,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
       "dev": true
     },
     "sparkles": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "postcss-scss": "^2.0.0",
     "puppeteer": "^1.9.0",
     "recursive-readdir": "^2.2.2",
+    "rollup-plugin-commonjs": "^9.2.1",
+    "rollup-plugin-node-resolve": "^4.0.1",
     "run-sequence": "^2.2.1",
     "sassdoc": "^2.5.0",
     "standard": "^11.0.1",

--- a/src/components/hmrc-account-menu/account-menu.js
+++ b/src/components/hmrc-account-menu/account-menu.js
@@ -1,3 +1,4 @@
+import '../../vendor/polyfills/Element/prototype/dataset'
 import { debounce } from '../../utils/debounce'
 
 function AccountMenu ($module) {
@@ -44,7 +45,7 @@ AccountMenu.prototype.eventHandlers = {
   },
   showSubnavLinkFocusOut: function (event) {
     if (!isSmall(window)) {
-      this.$module.querySelector(event.target.hash).dataset.subMenuTimer = setTimeout(0)
+      this.$module.querySelector(event.target.hash).dataset.subMenuTimer = setTimeout(function () {}, 0)
     }
   },
   showSubnavLinkFocusIn: function (event) {

--- a/src/vendor/polyfills/Element/prototype/dataset.js
+++ b/src/vendor/polyfills/Element/prototype/dataset.js
@@ -1,0 +1,57 @@
+import 'govuk-frontend/vendor/polyfills/Object/defineProperty'
+import 'govuk-frontend/vendor/polyfills/Function/prototype/bind'
+import '../../Object/getOwnPropertyDescriptor'
+import 'govuk-frontend/vendor/polyfills/Document'
+import 'govuk-frontend/vendor/polyfills/Element'
+import '../../document/querySelector'
+
+(function(undefined) {
+  // Detection from https://github.com/Financial-Times/polyfill-library/blob/master/polyfills/Element/prototype/dataset/detect.js
+  (function(){
+    if (!document.documentElement.dataset) {
+      return false;
+    }
+    var el = document.createElement('div');
+    el.setAttribute("data-a-b", "c");
+    return el.dataset && el.dataset.aB == "c";
+  }())
+
+  // Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Element.prototype.dataset&flags=always
+  Object.defineProperty(Element.prototype, 'dataset', {
+    get: function() {
+      var element = this;
+      var attributes = this.attributes;
+      var map = {};
+
+      for (var i = 0; i < attributes.length; i++) {
+        var attribute = attributes[i];
+
+        if (attribute && attribute.name && (/^data-\w[\w\-]*$/).test(attribute.name)) {
+          var name = attribute.name;
+          var value = attribute.value;
+
+          var propName = name.substr(5).replace(/-./g, function (prop) {
+            return prop.charAt(1).toUpperCase();
+          });
+
+          Object.defineProperty(map, propName, {
+            enumerable: this.enumerable,
+            get: function() {
+              return this.value;
+            }.bind({value: value || ''}),
+            set: function setter(name, value) {
+              if (typeof value !== 'undefined') {
+                this.setAttribute(name, value);
+              } else {
+                this.removeAttribute(name);
+              }
+            }.bind(element, name)
+          });
+        }
+      }
+
+      return map;
+    }
+  });
+})
+.call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});

--- a/src/vendor/polyfills/Object/getOwnPropertyDescriptor.js
+++ b/src/vendor/polyfills/Object/getOwnPropertyDescriptor.js
@@ -1,0 +1,124 @@
+(function(undefined) {
+
+    // Detection from https://github.com/Financial-Times/polyfill-library/blob/master/polyfills/Object/getOwnPropertyDescriptor/detect.js
+    var detect = (
+        'getOwnPropertyDescriptor' in Object && typeof Object.getOwnPropertyDescriptor === 'function' && (function() {
+            try {
+                var object = {};
+                object.test = 0;
+                return Object.getOwnPropertyDescriptor(
+                    object,
+                    "test"
+                ).value === 0;
+            } catch (exception) {
+                return false
+            }
+        }())
+    )
+
+    if (detect) return
+
+    // Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Object.getOwnPropertyDescriptor&flags=always
+    (function() {
+        var call = Function.prototype.call;
+        var prototypeOfObject = Object.prototype;
+        var owns = call.bind(prototypeOfObject.hasOwnProperty);
+
+        var lookupGetter;
+        var lookupSetter;
+        var supportsAccessors;
+        if ((supportsAccessors = owns(prototypeOfObject, "__defineGetter__"))) {
+            lookupGetter = call.bind(prototypeOfObject.__lookupGetter__);
+            lookupSetter = call.bind(prototypeOfObject.__lookupSetter__);
+        }
+        function doesGetOwnPropertyDescriptorWork(object) {
+            try {
+                object.sentinel = 0;
+                return Object.getOwnPropertyDescriptor(
+                    object,
+                    "sentinel"
+                ).value === 0;
+            } catch (exception) {
+                // returns falsy
+            }
+        }
+        // check whether getOwnPropertyDescriptor works if it's given. Otherwise,
+        // shim partially.
+        if (Object.defineProperty) {
+            var getOwnPropertyDescriptorWorksOnObject =
+                doesGetOwnPropertyDescriptorWork({});
+            var getOwnPropertyDescriptorWorksOnDom = typeof document == "undefined" ||
+                doesGetOwnPropertyDescriptorWork(document.createElement("div"));
+            if (!getOwnPropertyDescriptorWorksOnDom ||
+                !getOwnPropertyDescriptorWorksOnObject
+            ) {
+                var getOwnPropertyDescriptorFallback = Object.getOwnPropertyDescriptor;
+            }
+        }
+
+        if (!Object.getOwnPropertyDescriptor || getOwnPropertyDescriptorFallback) {
+            var ERR_NON_OBJECT = "Object.getOwnPropertyDescriptor called on a non-object: ";
+
+            Object.getOwnPropertyDescriptor = function getOwnPropertyDescriptor(object, property) {
+                if ((typeof object != "object" && typeof object != "function") || object === null) {
+                    throw new TypeError(ERR_NON_OBJECT + object);
+                }
+
+                // make a valiant attempt to use the real getOwnPropertyDescriptor
+                // for I8's DOM elements.
+                if (getOwnPropertyDescriptorFallback) {
+                    try {
+                        return getOwnPropertyDescriptorFallback.call(Object, object, property);
+                    } catch (exception) {
+                        // try the shim if the real one doesn't work
+                    }
+                }
+
+                // If object does not owns property return undefined immediately.
+                if (!owns(object, property)) {
+                    return;
+                }
+
+                // If object has a property then it's for sure both `enumerable` and
+                // `configurable`.
+                var descriptor = { enumerable: true, configurable: true };
+
+                // If JS engine supports accessor properties then property may be a
+                // getter or setter.
+                if (supportsAccessors) {
+                    // Unfortunately `__lookupGetter__` will return a getter even
+                    // if object has own non getter property along with a same named
+                    // inherited getter. To avoid misbehavior we temporary remove
+                    // `__proto__` so that `__lookupGetter__` will return getter only
+                    // if it's owned by an object.
+                    var prototype = object.__proto__;
+                    object.__proto__ = prototypeOfObject;
+
+                    var getter = lookupGetter(object, property);
+                    var setter = lookupSetter(object, property);
+
+                    // Once we have getter and setter we can put values back.
+                    object.__proto__ = prototype;
+
+                    if (getter || setter) {
+                        if (getter) {
+                            descriptor.get = getter;
+                        }
+                        if (setter) {
+                            descriptor.set = setter;
+                        }
+                        // If it was accessor property we're done and return here
+                        // in order to avoid adding `value` to the descriptor.
+                        return descriptor;
+                    }
+                }
+
+                // If we got this far we know that object has an own property that is
+                // not an accessor so we set it as a value and return descriptor.
+                descriptor.value = object[property];
+                descriptor.writable = true;
+                return descriptor;
+            };
+        }
+    }());
+}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});

--- a/src/vendor/polyfills/document/querySelector.js
+++ b/src/vendor/polyfills/document/querySelector.js
@@ -1,0 +1,68 @@
+import 'govuk-frontend/vendor/polyfills/Document'
+import 'govuk-frontend/vendor/polyfills/Element'
+
+(function(undefined) {
+
+  // Detection from https://github.com/Financial-Times/polyfill-library/blob/master/polyfills/document/querySelector/detect.js
+  var detect = (
+    'document' in this && 'querySelector' in this.document
+  )
+
+  if (detect) return
+
+  // Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always
+  (function () {
+    var
+    head = document.getElementsByTagName('head')[0];
+
+    function getElementsByQuery(node, selector, one) {
+      var
+      generator = document.createElement('div'),
+      id = 'qsa' + String(Math.random()).slice(3),
+      style, elements;
+
+      generator.innerHTML = 'x<style>' + selector + '{qsa:' + id + ';}';
+
+      style = head.appendChild(generator.lastChild);
+
+      elements = getElements(node, selector, one, id);
+
+      head.removeChild(style);
+
+      return one ? elements[0] : elements;
+    }
+
+    function getElements(node, selector, one, id) {
+      var
+      validNode = /1|9/.test(node.nodeType),
+      childNodes = node.childNodes,
+      elements = [],
+      index = -1,
+      childNode;
+
+      if (validNode && node.currentStyle && node.currentStyle.qsa === id) {
+        if (elements.push(node) && one) {
+          return elements;
+        }
+      }
+
+      while (childNode = childNodes[++index]) {
+        elements = elements.concat(getElements(childNode, selector, one, id));
+
+        if (one && elements.length) {
+          return elements;
+        }
+      }
+
+      return elements;
+    }
+
+    Document.prototype.querySelector = Element.prototype.querySelector = function querySelectorAll(selector) {
+      return getElementsByQuery(this, selector, true);
+    };
+
+    Document.prototype.querySelectorAll = Element.prototype.querySelectorAll = function querySelectorAll(selector) {
+      return getElementsByQuery(this, selector, false);
+    };
+  }());
+}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -8,6 +8,8 @@ const postcss = require('gulp-postcss')
 const autoprefixer = require('autoprefixer')
 const merge = require('merge-stream')
 const rollup = require('gulp-better-rollup')
+const resolve = require('rollup-plugin-node-resolve')
+const commonjs = require('rollup-plugin-commonjs')
 const taskArguments = require('./task-arguments')
 const gulpif = require('gulp-if')
 const uglify = require('gulp-uglify')
@@ -104,6 +106,11 @@ gulp.task('js:compile', () => {
     srcFiles
   ])
     .pipe(rollup({
+      plugins: [
+        resolve(),
+        commonjs()
+      ]
+    }, {
       // Used to set the `window` global and UMD/AMD export name.
       name: 'HMRCFrontend',
       // Legacy mode is required for IE8 support


### PR DESCRIPTION
### Add the html5shiv to our layout template so that the account header displays correctly

**Before**

![image](https://user-images.githubusercontent.com/1752124/53878643-557fda80-4004-11e9-9d11-6be7352ba264.png)

**After**

![image](https://user-images.githubusercontent.com/1752124/53878773-a1cb1a80-4004-11e9-87d3-55e40542543f.png)

### Polyfill the account menu for legacy browsers

Following the [govuk-frontend guidance on polyfilling](https://github.com/alphagov/govuk-frontend/blob/master/docs/contributing/polyfilling.md)

**Before**

![image](https://user-images.githubusercontent.com/1752124/53883162-2b341a00-4010-11e9-8078-2371a5abb984.png)

**After**

![image](https://user-images.githubusercontent.com/1752124/53883260-6898a780-4010-11e9-9b86-1b396880dcf9.png)
