### PR TITLE
Add sourcemaps

### DIFF
--- a/app/assets/scss/app.scss
+++ b/app/assets/scss/app.scss
@@ -3,5 +3,6 @@
 // to this list, ordered by width, e.g. (mobile, tablet, desktop).
 $mq-show-breakpoints: (mobile, tablet, desktop);
 
+@import "govuk-frontend/all";
 @import "../../../src/all";
 @import "partials/app";

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,7 +70,7 @@ gulp.task('copy-assets', cb => {
 // Runs a sequence of task on start
 // --------------------------------------
 gulp.task('dev', cb => {
-  runsequence('clean', 'copy-assets', 'sassdoc', 'serve', cb)
+  runsequence('clean', 'copy-assets', 'copy-dist-files', 'sassdoc', 'serve', cb)
 })
 
 // Serve task ---------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,29 @@
         }
       }
     },
+    "@gulp-sourcemaps/identity-map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz",
+      "integrity": "sha512-ciiioYMLdo16ShmfHBXJBOFm3xPC4AuwO4xeRpFeHz7WK9PYsWCmigagG2XyzZpubK4a3qNKoUBDhbzHfa50LQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.0.3",
+        "css": "^2.2.1",
+        "normalize-path": "^2.1.1",
+        "source-map": "^0.6.0",
+        "through2": "^2.0.3"
+      }
+    },
+    "@gulp-sourcemaps/map-sources": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+      "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^2.0.1",
+        "through2": "^2.0.3"
+      }
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -1609,6 +1632,18 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      }
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -1877,6 +1912,34 @@
       "dev": true,
       "requires": {
         "ms": "2.0.0"
+      }
+    },
+    "debug-fabulous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.1.0.tgz",
+      "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
+      "dev": true,
+      "requires": {
+        "debug": "3.X",
+        "memoizee": "0.4.X",
+        "object-assign": "4.X"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
       }
     },
     "debug-log": {
@@ -4934,43 +4997,29 @@
       }
     },
     "gulp-sourcemaps": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-      "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.5.tgz",
+      "integrity": "sha512-SYLBRzPTew8T5Suh2U8jCSDKY+4NARua4aqjj8HOysBh2tSgT9u4jc1FYirAdPx1akUxxDeK++fqw6Jg0LkQRg==",
       "dev": true,
       "requires": {
-        "convert-source-map": "^1.1.1",
-        "graceful-fs": "^4.1.2",
-        "strip-bom": "^2.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0"
+        "@gulp-sourcemaps/identity-map": "1.X",
+        "@gulp-sourcemaps/map-sources": "1.X",
+        "acorn": "5.X",
+        "convert-source-map": "1.X",
+        "css": "2.X",
+        "debug-fabulous": "1.X",
+        "detect-newline": "2.X",
+        "graceful-fs": "4.X",
+        "source-map": "~0.6.0",
+        "strip-bom-string": "1.X",
+        "through2": "2.X"
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
           "dev": true
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        },
-        "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true,
-          "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
-            "replace-ext": "0.0.1"
-          }
         }
       }
     },
@@ -7905,6 +7954,15 @@
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "magic-string": {
       "version": "0.25.2",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
@@ -8050,6 +8108,22 @@
       "resolved": "https://registry.npmjs.org/memoize-decorator/-/memoize-decorator-1.0.2.tgz",
       "integrity": "sha1-YFpBcVxBcdsZKpAJiwCrjW4RAvU=",
       "dev": true
+    },
+    "memoizee": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
+      "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.45",
+        "es6-weak-map": "^2.0.2",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.1",
+        "lru-queue": "0.1",
+        "next-tick": "1",
+        "timers-ext": "^0.1.5"
+      }
     },
     "meow": {
       "version": "3.7.0",
@@ -12363,6 +12437,19 @@
             "vinyl": "^1.0.0"
           },
           "dependencies": {
+            "gulp-sourcemaps": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+              "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+              "dev": true,
+              "requires": {
+                "convert-source-map": "^1.1.1",
+                "graceful-fs": "^4.1.2",
+                "strip-bom": "^2.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^1.0.0"
+              }
+            },
             "through2": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
@@ -13344,6 +13431,12 @@
         }
       }
     },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
+      "dev": true
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -13806,6 +13899,16 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
+    },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
     },
     "timsort": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gulp-rename": "^1.4.0",
     "gulp-sass": "^4.0.1",
     "gulp-sass-lint": "^1.4.0",
+    "gulp-sourcemaps": "^2.6.5",
     "gulp-uglify": "^3.0.1",
     "html5shiv": "^3.7.3",
     "jest": "^23.6.0",

--- a/src/components/hmrc-account-menu/_account-menu.scss
+++ b/src/components/hmrc-account-menu/_account-menu.scss
@@ -40,6 +40,7 @@ $hmrc-transition-type: "all";
 }
 
 .hmrc-account-menu {
+  @include govuk-font(16);
   @include govuk-clearfix;
   position: relative;
   z-index: 0;

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -41,8 +41,10 @@ const compileOldIeStylesheet = isDist ? configPaths.src + 'all-ie8.scss' : confi
 gulp.task('scss:compile', () => {
   let compile = gulp.src(compileStylesheet)
     .pipe(plumber(errorHandler))
-    .pipe(sass())
     .pipe(gulpif(!isPackage, sourcemaps.init()))
+    .pipe(sass({
+      includePaths: ['node_modules']
+    }))
     // minify css add vendor prefixes and normalize to compiled css
     .pipe(gulpif(isDist, postcss([
       autoprefixer,
@@ -67,8 +69,10 @@ gulp.task('scss:compile', () => {
 
   let compileOldIe = gulp.src(compileOldIeStylesheet)
     .pipe(plumber(errorHandler))
-    .pipe(sass())
     .pipe(gulpif(!isPackage, sourcemaps.init()))
+    .pipe(sass({
+      includePaths: ['node_modules']
+    }))
     // minify css add vendor prefixes and normalize to compiled css
     .pipe(gulpif(isDist, postcss([
       autoprefixer,

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -17,12 +17,14 @@ const eol = require('gulp-eol')
 const rename = require('gulp-rename')
 const cssnano = require('cssnano')
 const postcsspseudoclasses = require('postcss-pseudo-classes')
+const sourcemaps = require('gulp-sourcemaps')
 
 // Compile CSS and JS task --------------
 // --------------------------------------
 
 // check if destination flag is dist
 const isDist = taskArguments.destination === 'dist' || false
+const isPackage = taskArguments.destination === 'package' || false
 
 const errorHandler = function (error) {
   // Log the error to the console
@@ -40,6 +42,7 @@ gulp.task('scss:compile', () => {
   let compile = gulp.src(compileStylesheet)
     .pipe(plumber(errorHandler))
     .pipe(sass())
+    .pipe(gulpif(!isPackage, sourcemaps.init()))
     // minify css add vendor prefixes and normalize to compiled css
     .pipe(gulpif(isDist, postcss([
       autoprefixer,
@@ -57,11 +60,15 @@ gulp.task('scss:compile', () => {
         extname: '.min.css'
       })
     ))
+    // Write external sourcemap files to the root of the destination directory,
+    // but not for the npm package
+    .pipe(gulpif(!isPackage, sourcemaps.write('./')))
     .pipe(gulp.dest(taskArguments.destination + '/'))
 
   let compileOldIe = gulp.src(compileOldIeStylesheet)
     .pipe(plumber(errorHandler))
     .pipe(sass())
+    .pipe(gulpif(!isPackage, sourcemaps.init()))
     // minify css add vendor prefixes and normalize to compiled css
     .pipe(gulpif(isDist, postcss([
       autoprefixer,
@@ -91,6 +98,9 @@ gulp.task('scss:compile', () => {
         extname: '.min.css'
       })
     ))
+    // Write external sourcemap files to the root of the destination directory,
+    // but not for the npm package
+    .pipe(gulpif(!isPackage, sourcemaps.write('./')))
     .pipe(gulp.dest(taskArguments.destination + '/'))
 
   return merge(compile, compileOldIe)
@@ -105,6 +115,7 @@ gulp.task('js:compile', () => {
     '!' + configPaths.src + '**/*.test.js',
     srcFiles
   ])
+    .pipe(gulpif(!isPackage, sourcemaps.init()))
     .pipe(rollup({
       plugins: [
         resolve(),
@@ -126,5 +137,8 @@ gulp.task('js:compile', () => {
       })
     ))
     .pipe(eol())
+    // Write external sourcemap files to the root of the destination directory,
+    // but not for the npm package
+    .pipe(gulpif(!isPackage, sourcemaps.write('./')))
     .pipe(gulp.dest(taskArguments.destination + '/'))
 })


### PR DESCRIPTION
This PR adds sourcemaps for development and dist output but not to the npm package.

While testing them in the preview app I noticed a few other things that have been fixed up by this PR too..

* Since #29 we now don't bundle govuk-frontend into the output of hmrc-frontend (😄). This meant the govuk styles had disappeared from the preview app (😞). so i've added them back (😄).
* Also as part of #29 the font and image files get copied to destination directory, but `gulp dev` got overlooked so they were broken links in the preview app. Now they get copied to `/public` for the preview app too.
* Finally, the account menu items weren't having the govuk font applied to them as a result of #29, so now they do.