### PR TITLE
SDT-884 Add to a list component

### DIFF
--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -9,10 +9,9 @@ const yaml = require('js-yaml')
 const configPaths = require('../config/paths.json')
 const { componentNameToMacroName } = require('./helper-functions.js')
 
-nunjucks.configure(configPaths.components, {
-  trimBlocks: true,
-  lstripBlocks: true
-})
+nunjucks.configure(
+  [ configPaths.components, path.join(configPaths.govukFrontend, 'components') ],
+  { trimBlocks: true, lstripBlocks: true })
 
 /**
  * Render a component's macro for testing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/_all.scss
+++ b/src/components/_all.scss
@@ -4,3 +4,4 @@
 @import "hmrc-language-select/language-select";
 @import "hmrc-header/header";
 @import "hmrc-internal-header/internal-header";
+@import "hmrc-add-to-a-list/add-to-a-list";

--- a/src/components/hmrc-add-to-a-list/_add-to-a-list.scss
+++ b/src/components/hmrc-add-to-a-list/_add-to-a-list.scss
@@ -41,12 +41,6 @@
   }
 }
 
-.hmrc-add-to-a-list__contents:first-child dt {
-  @include mq($from: desktop) {
-    padding-top: 0;
-  }
-}
-
 .hmrc-add-to-a-list__identifier,
 .hmrc-add-to-a-list__remove,
 .hmrc-add-to-a-list__change {

--- a/src/components/hmrc-add-to-a-list/_add-to-a-list.scss
+++ b/src/components/hmrc-add-to-a-list/_add-to-a-list.scss
@@ -1,0 +1,95 @@
+.hmrc-add-to-a-list {
+  @include govuk-font($size: 19);
+  @include mq($from: desktop) {
+    display: table;
+  }
+}
+
+.hmrc-add-to-a-list--short {
+  @include mq($from: desktop) {
+    // to make group of q&a line up horizontally (unless there is just one group)
+    width: 100%;
+
+    // recommended for mostly short questions
+    .hmrc-add-to-a-list__question {
+      width: 30%;
+    }
+  }
+}
+
+.hmrc-add-to-a-list--long {
+  @include mq($from: desktop) {
+    // to make group of q&a line up horizontally (unless there is just one group)
+    width: 100%;
+
+    // recommended for mostly long questions
+    .hmrc-add-to-a-list__question {
+      width: 50%;
+    }
+  }
+}
+
+.hmrc-add-to-a-list__contents {
+  position: relative;
+  padding-bottom: govuk-spacing(1);
+  border-bottom: 1px solid $govuk-border-colour;
+  @include mq($from: desktop) {
+    display: table-row;
+    padding-bottom: 0;
+    border-bottom-width: 0;
+  }
+}
+
+.hmrc-add-to-a-list__contents:first-child dt {
+  @include mq($from: desktop) {
+    padding-top: 0;
+  }
+}
+
+.hmrc-add-to-a-list__identifier,
+.hmrc-add-to-a-list__remove,
+.hmrc-add-to-a-list__change {
+  display: block;
+  margin: 0;
+  @include mq($from: desktop) {
+    display: table-cell;
+    padding: govuk-spacing(3) 0;
+    border-bottom: 1px solid $govuk-border-colour;
+  }
+}
+
+.hmrc-add-to-a-list__identifier {
+  margin: govuk-spacing(2) govuk-spacing(9) 0 0;
+  font-weight: bold;
+  @include mq($from: desktop) {
+    margin: 0;
+  }
+}
+
+.hmrc-add-to-a-list__identifier--light {
+  font-weight: normal;
+}
+
+.hmrc-add-to-a-list__remove {
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(2);
+  text-align: right;
+
+  @include mq($from: desktop) {
+    padding-right: 0;
+  }
+}
+
+.hmrc-add-to-a-list__change {
+  position: absolute;
+  top: 0;
+  right: 0;
+  text-align: right;
+  @include mq($from: desktop) {
+    position: static;
+
+    + .hmrc-add-to-a-list__remove {
+      width: 6em;
+    }
+  }
+}

--- a/src/components/hmrc-add-to-a-list/_add-to-a-list.scss
+++ b/src/components/hmrc-add-to-a-list/_add-to-a-list.scss
@@ -1,5 +1,5 @@
 .hmrc-add-to-a-list {
-  padding-inline-start: 0;
+  padding-left: 0;
   @include govuk-font($size: 19);
   @include mq($from: desktop) {
     display: table;

--- a/src/components/hmrc-add-to-a-list/_add-to-a-list.scss
+++ b/src/components/hmrc-add-to-a-list/_add-to-a-list.scss
@@ -1,4 +1,5 @@
 .hmrc-add-to-a-list {
+  padding-inline-start: 0;
   @include govuk-font($size: 19);
   @include mq($from: desktop) {
     display: table;

--- a/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
+++ b/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
@@ -57,7 +57,7 @@ examples:
     hintText: You must tell us about all your directors
     formAction: '#addDirector'
 
-- name: signleitem
+- name: singleitem
   description: A list with a single unnamed item
   data:
     itemList:

--- a/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
+++ b/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
@@ -50,8 +50,15 @@ examples:
   data:
     itemList:
         - { name: Director One, changeUrl: '#c1url', removeUrl: '#r1url' }
-        - { name: Director Two, changeUrl: '#c1url', removeUrl: '#r1url'}
+        - { name: Director Two, changeUrl: '#c2url', removeUrl: '#r2url' }
     itemType:
       singular: director
       plural: directors
     hintText: You must tell us about all your directors
+    formAction: '#addDirector'
+
+- name: signleitem
+  description: A list with a single unnamed item
+  data:
+    itemList:
+      - { name: item one, changeUrl: '#c1url', removeUrl: '#r1url' }

--- a/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
+++ b/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
@@ -1,0 +1,22 @@
+params:
+  - itemList:
+    type: array
+    required: true
+    description: the list of items being added to
+
+
+
+examples:
+- name: default
+  description: A default example.
+  data: {}
+
+- name: directors
+  data:
+    itemList:
+        - { name: Director One, changeUrl: '#c1url', removeUrl: '#r1url' }
+        - { name: Director Two, changeUrl: '#c1url', removeUrl: '#r1url'}
+    itemType:
+      singular: director
+      plural: directors
+    hintText: 'You must tell us about all your directors'

--- a/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
+++ b/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
@@ -3,8 +3,43 @@ params:
     type: array
     required: true
     description: the list of items being added to
+    params:
+      - name:
+        type: string
+        required: true
+        description: the identifier for this item
 
+      - changeUrl:
+        type: string
+        description: the URL to edit the details for this item
 
+      - removeUrl:
+        type: string
+        description: the URL to remove this item from the list
+
+  - itemType:
+      - singular:
+        type: string
+        required: false
+        default: Item
+        description: Noun used for a single entry in the itemList
+
+      - plural:
+        type: string
+        required: false
+        default: Items
+        description: Noun used for multiple entries in the itemList
+
+      - itemSize:
+        type: string
+        required: false
+        default: short
+        description: 'short or long, used to choose the correct css classes for the first column text'
+
+      - formAction:
+        type: string
+        required: true
+        description: URL used to handle the form
 
 examples:
 - name: default
@@ -19,4 +54,4 @@ examples:
     itemType:
       singular: director
       plural: directors
-    hintText: 'You must tell us about all your directors'
+    hintText: You must tell us about all your directors

--- a/src/components/hmrc-add-to-a-list/macro.njk
+++ b/src/components/hmrc-add-to-a-list/macro.njk
@@ -1,0 +1,3 @@
+{% macro hmrcAddToAList(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/components/hmrc-add-to-a-list/template.njk
+++ b/src/components/hmrc-add-to-a-list/template.njk
@@ -21,7 +21,6 @@
       </span>
     </div>
     {% else %}
-    <p>Your list is empty.</p>
       {# empty list stuff goes here #}
     {% endfor %}
     {# end loop #}

--- a/src/components/hmrc-add-to-a-list/template.njk
+++ b/src/components/hmrc-add-to-a-list/template.njk
@@ -7,10 +7,10 @@
 {%- endif -%}
 </h1>
 <div class="govuk-form-group">
-  <div class="hmrc-add-to-a-list hmrc-add-to-a-list--{{ params.itemSize | default('short') }}">
+  <ul class="hmrc-add-to-a-list hmrc-add-to-a-list--{{ params.itemSize | default('short') }}">
     {# loop through items in  the itemList #}
     {% for item in params.itemList %}
-    <div class="hmrc-add-to-a-list__contents">
+    <li class="hmrc-add-to-a-list__contents">
       <span class="hmrc-add-to-a-list__identifier hmrc-add-to-a-list__identifier--light">
         {{ item.name }}
       </span>
@@ -26,12 +26,12 @@
           <span class="govuk-visually-hidden">Remove {{item.name}} from the list</span>
         </a>
       </span>
-    </div>
+    </li>
     {% else %}
       {# empty list stuff goes here #}
     {% endfor %}
     {# end loop #}
-  </div>
+  </ul>
 </div>
 <form method="post" action="{{ params.formAction }}">
   {{ govukRadios({

--- a/src/components/hmrc-add-to-a-list/template.njk
+++ b/src/components/hmrc-add-to-a-list/template.njk
@@ -1,0 +1,52 @@
+<h1 class="govuk-heading-xl">You have added {{ params.itemList | length | default('no', true)}} {{ params.itemType.plural | default('items')}}</h1>
+<div class="govuk-form-group">
+  <div class="hmrc-add-to-a-list hmrc-add-to-a-list--{{ params.itemSize | default('short') }}">
+    {# loop through items in  the itemList #}
+    {% for item in params.itemList %}
+    <div class="hmrc-add-to-a-list__contents">
+      <span class="hmrc-add-to-a-list__identifier hmrc-add-to-a-list__identifier--light">
+        {{ item.name }}
+      </span>
+      <span class="hmrc-add-to-a-list__change">
+        <a class="govuk-link" href="{{ item.changeUrl }}">
+          <span aria-hidden="true">Change</span>
+          <span class="govuk-visually-hidden">Change {{ item.name }}</span>
+        </a>
+      </span>
+      <span class="hmrc-add-to-a-list__remove">
+        <a class="govuk-link" href="{{ item.removeUrl }}">
+          <span aria-hidden="true">Remove</span>
+          <span class="govuk-visually-hidden">Remove {{item.name}} from the list</span>
+        </a>
+      </span>
+    </div>
+    {% else %}
+    <p>Your list is empty.</p>
+      {# empty list stuff goes here #}
+    {% endfor %}
+    {# end loop #}
+  </div>
+</div>
+<form method="post" action="{{ params.formAction }}">
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset" id="add-another" aria-describedby="add-another-hint">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Do you need to add another {{params.itemType.singular | default('item') }}?</legend>
+      <span class="govuk-hint" id="add-another-hint">{{ params.hintText }}</span>
+      <div class="govuk-radios govuk-radios--inline">
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="add-another-yes" type="radio" name="add-another" value="true">
+          <label class="govuk-radios__label" for="add-another-yes">
+            Yes
+          </label>
+        </div>
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="add-another-no" type="radio" name="add-another" value="false">
+          <label class="govuk-radios__label" for="add-another-no">
+            No
+          </label>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+  <button type="submit" class="govuk-button">Continue</button>
+</form>

--- a/src/components/hmrc-add-to-a-list/template.njk
+++ b/src/components/hmrc-add-to-a-list/template.njk
@@ -1,7 +1,11 @@
 {% from "button/macro.njk" import govukButton with context%}
 {% from "radios/macro.njk" import govukRadios with context %}
 
-<h1 class="govuk-heading-xl">You have added {{ params.itemList | length | default('no', true)}} {{ params.itemType.plural | default('items')}}</h1>
+<h1 class="govuk-heading-xl">You have added {{ params.itemList | length | default('no', true) }}
+{%- if params.itemList | length  === 1 %} {{ params.itemType.singular | default('item') }}
+{%- else %} {{ params.itemType.plural | default('items') }}
+{%- endif -%}
+</h1>
 <div class="govuk-form-group">
   <div class="hmrc-add-to-a-list hmrc-add-to-a-list--{{ params.itemSize | default('short') }}">
     {# loop through items in  the itemList #}

--- a/src/components/hmrc-add-to-a-list/template.njk
+++ b/src/components/hmrc-add-to-a-list/template.njk
@@ -1,3 +1,6 @@
+{% from "button/macro.njk" import govukButton with context%}
+{% from "radios/macro.njk" import govukRadios with context %}
+
 <h1 class="govuk-heading-xl">You have added {{ params.itemList | length | default('no', true)}} {{ params.itemType.plural | default('items')}}</h1>
 <div class="govuk-form-group">
   <div class="hmrc-add-to-a-list hmrc-add-to-a-list--{{ params.itemSize | default('short') }}">
@@ -27,25 +30,23 @@
   </div>
 </div>
 <form method="post" action="{{ params.formAction }}">
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset" id="add-another" aria-describedby="add-another-hint">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Do you need to add another {{params.itemType.singular | default('item') }}?</legend>
-      <span class="govuk-hint" id="add-another-hint">{{ params.hintText }}</span>
-      <div class="govuk-radios govuk-radios--inline">
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="add-another-yes" type="radio" name="add-another" value="true">
-          <label class="govuk-radios__label" for="add-another-yes">
-            Yes
-          </label>
-        </div>
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="add-another-no" type="radio" name="add-another" value="false">
-          <label class="govuk-radios__label" for="add-another-no">
-            No
-          </label>
-        </div>
-      </div>
-    </fieldset>
-  </div>
-  <button type="submit" class="govuk-button">Continue</button>
+  {{ govukRadios({
+    classes: "govuk-radios--inline",
+    idPrefix: "add-another",
+    name: "add-another",
+    fieldset: {
+      legend: {
+        text:  "Do you need to add another " + params.itemType.singular | default('item') + "?",
+        isPageHeading: false,
+        classes: "govuk-fieldset__legend govuk-fieldset__legend--m"
+      }
+    },
+    hint: {
+      text: params.hintText
+    },
+    items: [
+      { text: "Yes", value: "yes" },
+      { text: "No", value: "no" }
+    ] }) }}
+  {{ govukButton({ text: " Submit " }) }}
 </form>

--- a/src/components/hmrc-add-to-a-list/template.test.js
+++ b/src/components/hmrc-add-to-a-list/template.test.js
@@ -1,0 +1,71 @@
+/* eslint-env jest */
+
+const { render, getExamples } = require('../../../lib/jest-helpers')
+
+const examples = getExamples('add-to-a-list')
+
+describe('Add to a list', () => {
+  describe('by default', () => {
+    const $ = render('add-to-a-list', examples.default)
+    const $heading = $('h1')
+    const $legend = $('fieldset legend')
+    it('Uses \'items\' as the plural item name', () => {
+      expect($heading.text()).toContain('items')
+    })
+    it('Uses \'no\' as the count value', () => {
+      expect($heading.text()).toContain('no items')
+    })
+    it('has the default legend text', () => {
+      expect($legend.text()).toContain('Do you need to add another item?')
+    })
+  })
+
+  describe('with one item', () => {
+    const $ = render('add-to-a-list', examples.signleitem)
+    const $heading = $('h1')
+    const $rows = $('.hmrc-add-to-a-list__contents')
+    it('Uses \'item\' as the singular item name', () => {
+      expect($heading.text()).toContain('item')
+    })
+    it('Uses \'1\' as the count value', () => {
+      expect($heading.text()).toContain('1 item')
+    })
+    it('Contains a list of 1 item', () => {
+      expect($rows.length).toBe(1)
+      expect($('span.hmrc-add-to-a-list__identifier', $rows).text()).toContain('item one')
+      expect($('span.hmrc-add-to-a-list__change', $rows).text()).toContain('Change')
+      expect($('span.hmrc-add-to-a-list__remove', $rows).text()).toContain('Remove')
+      expect($('span.hmrc-add-to-a-list__change .govuk-visually-hidden', $rows).text()).toContain('Change item one')
+      expect($('span.hmrc-add-to-a-list__remove .govuk-visually-hidden', $rows).text()).toContain('Remove item one from the list')
+    })
+  })
+
+  describe('with two named items', () => {
+    const $ = render('add-to-a-list', examples.directors)
+    const $heading = $('h1')
+    const $rows = $('.hmrc-add-to-a-list__contents')
+    const $legend = $('fieldset legend')
+    const $form = $('form')
+    it('Uses \'directors\' as the plural item name', () => {
+      expect($heading.text()).toContain('directors')
+    })
+    it('Uses \'2\' as the count value', () => {
+      expect($heading.text()).toContain('2 directors')
+    })
+    it('Contains a list of 2 directors', () => {
+      expect($rows.length).toBe(2)
+      expect($('span.hmrc-add-to-a-list__identifier', $rows).eq(0).text()).toContain('Director One')
+      expect($('span.hmrc-add-to-a-list__change .govuk-visually-hidden', $rows).eq(0).text()).toContain('Change Director One')
+      expect($('span.hmrc-add-to-a-list__remove .govuk-visually-hidden', $rows).eq(0).text()).toContain('Remove Director One from the list')
+      expect($('span.hmrc-add-to-a-list__identifier', $rows).eq(1).text()).toContain('Director Two')
+      expect($('span.hmrc-add-to-a-list__change .govuk-visually-hidden', $rows).eq(1).text()).toContain('Change Director Two')
+      expect($('span.hmrc-add-to-a-list__remove .govuk-visually-hidden', $rows).eq(1).text()).toContain('Remove Director Two from the list')
+    })
+    it('has the item type in the legend text', () => {
+      expect($legend.text()).toContain('Do you need to add another director?')
+    })
+    it('has an action set on the form', () => {
+      expect($form.attr('action')).toBe('#addDirector')
+    })
+  })
+})

--- a/src/components/hmrc-add-to-a-list/template.test.js
+++ b/src/components/hmrc-add-to-a-list/template.test.js
@@ -21,7 +21,7 @@ describe('Add to a list', () => {
   })
 
   describe('with one item', () => {
-    const $ = render('add-to-a-list', examples.signleitem)
+    const $ = render('add-to-a-list', examples.singleitem)
     const $heading = $('h1')
     const $rows = $('.hmrc-add-to-a-list__contents')
     it('Uses \'item\' as the singular item name', () => {


### PR DESCRIPTION
## Create a component for the Summary List used for items in the Add to a List pattern.
Realise the unique part of the Add to a List pattern as a component for use in prototypes
### Decisions: 
- Include the form used to initiate the journey to add another item.
- Depart from the api used in the GOVUK Frontend summary list component, they require more flexibility than we do in this particular pattern
- Like the other patterns we have already completed this doesn't include Welsh Language support 

### Default appearance with an Empty List
![Screenshot from 2019-03-15 10-40-19](https://user-images.githubusercontent.com/234825/54427926-c8c7d180-4713-11e9-8bb4-ef5b8a484461.png)

### With an single item using the default item name
![Screenshot from 2019-03-15 10-41-53](https://user-images.githubusercontent.com/234825/54427960-e7c66380-4713-11e9-85b1-5c9f238c3412.png)

### With multiple items named director/directors and some hint text
![Screenshot from 2019-03-15 10-41-32](https://user-images.githubusercontent.com/234825/54427998-fe6cba80-4713-11e9-8e4b-5b3a3e8828f2.png)
 