### PR TITLE
DDCNLS-5647 Enable the focus highlight on the 'Your account' link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/hmrc-account-menu/_account-menu.scss
+++ b/src/components/hmrc-account-menu/_account-menu.scss
@@ -392,8 +392,6 @@ hmrc-subnav__section__heading {
 .js-enabled .hmrc-account-menu__link--more {
   position: relative;
   padding-right: 31px;
-  border-bottom: 0;
-  outline: none;
   background-image: url("#{$hmrc-assets-path}components/hmrc-account-menu/images/icon-chevron-down.svg");
   background-position: right 14px center;
   background-size: 12px;


### PR DESCRIPTION
### Enable the visual highlight when the **Your account** link in the menu is focused

Duplicating a change being implemented in assets-frontend to keep the two implementations of the Account Menu component in sync.

### Before
![Screenshot from 2019-04-11 10-18-32](https://user-images.githubusercontent.com/234825/55945797-67781d00-5c43-11e9-90a0-75d317a0f50e.png)

### After
![Screenshot from 2019-04-11 10-18-52](https://user-images.githubusercontent.com/234825/55945830-752da280-5c43-11e9-96ac-8cd9adb2406f.png)
