### PR TITLE
Sdt 1039 welsh add to a list

### DIFF
--- a/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
+++ b/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
@@ -21,13 +21,13 @@ params:
       - singular:
         type: string
         required: false
-        default: Item
+        default: item
         description: Noun used for a single entry in the itemList
 
       - plural:
         type: string
         required: false
-        default: Items
+        default: items
         description: Noun used for multiple entries in the itemList
 
       - itemSize:
@@ -49,6 +49,15 @@ examples:
 - name: single-generic-item
   description: A list with a single unnamed item
   data:
+    itemList:
+      - name: item one
+        changeUrl: '#c1url'
+        removeUrl: '#r1url'
+
+- name: single-generic-welsh-item
+  description: A list with a single unnamed item
+  data:
+    language: 'cy'
     itemList:
       - name: item one
         changeUrl: '#c1url'

--- a/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
+++ b/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
@@ -49,6 +49,12 @@ examples:
   data:
     itemlist: []
 
+- name: empty-list-welsh
+  description: A default example.
+  data:
+    language: 'cy'
+    itemlist: []
+
 - name: single-generic-item
   description: A list with a single unnamed item
   data:
@@ -82,3 +88,16 @@ examples:
           removeUrl: '#remove-item-2'
     hintText: You must tell us about all your directors
     formAction: '#add-director'
+
+- name: mutltiple-generic-welsh-items
+  description: A list with a single unnamed item using Welsh language
+  data:
+    language: 'cy'
+    itemList:
+      - name: Eitem un
+        changeUrl: '#c1url'
+        removeUrl: '#r1url'
+      - name: Eitem dau
+        changeUrl: '#c2url'
+        removeUrl: '#r2url'
+    formAction: '#addItem'

--- a/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
+++ b/src/components/hmrc-add-to-a-list/add-to-a-list.yaml
@@ -11,10 +11,12 @@ params:
 
       - changeUrl:
         type: string
+        required: true
         description: the URL to edit the details for this item
 
       - removeUrl:
         type: string
+        required: true
         description: the URL to remove this item from the list
 
   - itemType:
@@ -45,6 +47,7 @@ examples:
 - name: default
   description: A default example.
   data:
+    itemlist: []
 
 - name: single-generic-item
   description: A list with a single unnamed item
@@ -53,6 +56,7 @@ examples:
       - name: item one
         changeUrl: '#c1url'
         removeUrl: '#r1url'
+    formAction: '#addItem'
 
 - name: single-generic-welsh-item
   description: A list with a single unnamed item
@@ -62,6 +66,7 @@ examples:
       - name: item one
         changeUrl: '#c1url'
         removeUrl: '#r1url'
+    formAction: '#addItem'
 
 - name: multiple-specific-items
   data:

--- a/src/components/hmrc-add-to-a-list/template.njk
+++ b/src/components/hmrc-add-to-a-list/template.njk
@@ -1,9 +1,33 @@
-{% from "button/macro.njk" import govukButton with context%}
+{% from "button/macro.njk" import govukButton with context %}
 {% from "radios/macro.njk" import govukRadios with context %}
-
-<h1 class="govuk-heading-xl">You have added {{ params.itemList | length | default('no', true) }}
-{%- if params.itemList | length  === 1 %} {{ params.itemType.singular | default('item') }}
-{%- else %} {{ params.itemType.plural | default('items') }}
+{% if params.language == 'cy' %}
+    {% set messages = {
+    itemTypeDefault: {singular: 'item-cy', plural: 'items-cy', noItems: 'items-cy'},
+    haveAdded: 'You have added - cy',
+    addAnother: 'Do you need to add another - cy',
+    continue: 'continue-cy',
+    change: 'Change-cy',
+    remove: 'Remove-cy',
+    aria: {before: 'Remove-cy', after: 'from the list'},
+    yes : 'yes-cy',
+    no: 'no-cy'
+  } %}
+{% else %}
+  {% set messages = {
+    itemTypeDefault: {singular: 'item', plural: 'items', noItems: 'items'},
+    haveAdded: 'You have added',
+    addAnother: 'Do you need to add another',
+    continue: 'continue',
+    change: 'Change',
+    remove: 'Remove',
+    aria: {before: 'Remove', after: 'from the list'},
+    yes : 'yes',
+    no: 'no'
+  } %}
+{% endif %}
+<h1 class="govuk-heading-xl">{{ messages.haveAdded }} {{ params.itemList | length | default('no', true) }}
+{%- if params.itemList | length  === 1 %} {{ params.itemType.singular | default(messages.itemTypeDefault.singular) }}
+{%- else %} {{ params.itemType.plural | default(messages.itemTypeDefault.plural) }}
 {%- endif -%}
 </h1>
 <div class="govuk-form-group">
@@ -16,14 +40,14 @@
       </span>
       <span class="hmrc-add-to-a-list__change">
         <a class="govuk-link" href="{{ item.changeUrl }}">
-          <span aria-hidden="true">Change</span>
-          <span class="govuk-visually-hidden">Change {{ item.name }}</span>
+          <span aria-hidden="true">{{messages.change}}</span>
+          <span class="govuk-visually-hidden">{{messages.change}} {{ item.name }}</span>
         </a>
       </span>
       <span class="hmrc-add-to-a-list__remove">
         <a class="govuk-link" href="{{ item.removeUrl }}">
-          <span aria-hidden="true">Remove</span>
-          <span class="govuk-visually-hidden">Remove {{item.name}} from the list</span>
+          <span aria-hidden="true">{{messages.remove}}</span>
+          <span class="govuk-visually-hidden">{{messages.aria.before}} {{ item.name }} {{messages.aria.after}}</span>
         </a>
       </span>
     </li>
@@ -40,7 +64,7 @@
     name: "add-another",
     fieldset: {
       legend: {
-        text:  "Do you need to add another " + params.itemType.singular | default('item') + "?",
+        text:  messages.addAnother + " " + params.itemType.singular | default(messages.itemTypeDefault.singular) + "?",
         isPageHeading: false,
         classes: "govuk-fieldset__legend govuk-fieldset__legend--m"
       }
@@ -49,8 +73,8 @@
       text: params.hintText
     },
     items: [
-      { text: "Yes", value: "yes" },
-      { text: "No", value: "no" }
+      { text: messages.yes, value: "yes" },
+      { text: messages.no, value: "no" }
     ] }) }}
-  {{ govukButton({ text: " Submit " }) }}
+  {{ govukButton({ text: messages.continue }) }}
 </form>

--- a/src/components/hmrc-add-to-a-list/template.njk
+++ b/src/components/hmrc-add-to-a-list/template.njk
@@ -2,21 +2,23 @@
 {% from "radios/macro.njk" import govukRadios with context %}
 {% if params.language == 'cy' %}
     {% set messages = {
-    itemTypeDefault: {singular: 'item-cy', plural: 'items-cy', noItems: 'items-cy'},
-    haveAdded: 'You have added - cy',
-    addAnother: 'Do you need to add another - cy',
-    continue: 'continue-cy',
-    change: 'Change-cy',
-    remove: 'Remove-cy',
-    aria: {before: 'Remove-cy', after: 'from the list'},
-    yes : 'yes-cy',
-    no: 'no-cy'
+    itemTypeDefault: {singular: 'eitem', plural: 'o eitemau'},
+    emptyList: 'Nid ydych wedi ychwanegu unrhyw eitemau',
+    haveAdded: 'Rydych wedi ychwanegu',
+    addAnother: {prefix: 'Oes angen i chi ychwanegu', suffix: ' arall'},
+    continue: 'Yn eich blaen',
+    change: 'Newid',
+    remove: 'Dileu',
+    aria: {before: 'Dileu’r', after: 'o’r rhestr'},
+    yes : 'iawn',
+    no: 'na'
   } %}
 {% else %}
   {% set messages = {
-    itemTypeDefault: {singular: 'item', plural: 'items', noItems: 'items'},
+    itemTypeDefault: {singular: 'item', plural: 'items'},
+    emptyList: 'You have not added any items',
     haveAdded: 'You have added',
-    addAnother: 'Do you need to add another',
+    addAnother: {prefix: 'Do you need to add another', suffix: ''},
     continue: 'continue',
     change: 'Change',
     remove: 'Remove',
@@ -25,9 +27,13 @@
     no: 'no'
   } %}
 {% endif %}
-<h1 class="govuk-heading-xl">{{ messages.haveAdded }} {{ params.itemList | length | default('no', true) }}
-{%- if params.itemList | length  === 1 %} {{ params.itemType.singular | default(messages.itemTypeDefault.singular) }}
-{%- else %} {{ params.itemType.plural | default(messages.itemTypeDefault.plural) }}
+<h1 class="govuk-heading-xl">{%- if params.itemList | length === 0 -%}
+  {{ messages.emptyList }}
+{%- else -%}
+  {{ messages.haveAdded }} {{ params.itemList | length }}
+  {%- if params.itemList | length  === 1 %} {{ params.itemType.singular | default(messages.itemTypeDefault.singular) }}
+  {%- else %} {{ params.itemType.plural | default(messages.itemTypeDefault.plural) }}
+{%- endif -%}
 {%- endif -%}
 </h1>
 <div class="govuk-form-group">
@@ -64,7 +70,7 @@
     name: "add-another",
     fieldset: {
       legend: {
-        text:  messages.addAnother + " " + params.itemType.singular | default(messages.itemTypeDefault.singular) + "?",
+        text:  messages.addAnother.prefix + " " + params.itemType.singular | default(messages.itemTypeDefault.singular) + messages.addAnother.suffix + "?",
         isPageHeading: false,
         classes: "govuk-fieldset__legend govuk-fieldset__legend--m"
       }
@@ -73,8 +79,8 @@
       text: params.hintText
     },
     items: [
-      { text: messages.yes, value: "yes" },
-      { text: messages.no, value: "no" }
+      { text: messages.yes, value: messages.yes },
+      { text: messages.no, value: messages.yes }
     ] }) }}
   {{ govukButton({ text: messages.continue }) }}
 </form>

--- a/src/components/hmrc-add-to-a-list/template.test.js
+++ b/src/components/hmrc-add-to-a-list/template.test.js
@@ -4,22 +4,33 @@ const { render, getExamples } = require('../../../lib/jest-helpers')
 
 const examples = getExamples('add-to-a-list')
 
+const getTableItems = ($) => {
+  const $rows = $('.hmrc-add-to-a-list__contents')
+  const $changeLinks = $('span.hmrc-add-to-a-list__change', $rows)
+  const $removeLinks = $('span.hmrc-add-to-a-list__remove', $rows)
+
+  const listItems = {}
+  listItems.identifiers = $('span.hmrc-add-to-a-list__identifier', $rows)
+  listItems.changeLinkText = $changeLinks.find('[aria-hidden="true"]').eq(0).text().trim()
+  listItems.removeLinkText = $removeLinks.find('[aria-hidden="true"]').eq(0).text().trim()
+  listItems.ariaChangeText = $changeLinks.find('.govuk-visually-hidden').eq(0).text().trim()
+  listItems.ariaRemoveText = $removeLinks.find('.govuk-visually-hidden').eq(0).text().trim()
+
+  return listItems
+}
+
 describe('Add to a list', () => {
   describe('by default', () => {
     const $ = render('add-to-a-list', examples['default'])
     const $heading = $('h1')
     const $legend = $('fieldset legend')
 
-    it('Uses "items" as the plural item name', () => {
-      expect($heading.text()).toContain('items')
-    })
-
-    it('Uses "no" as the count value', () => {
-      expect($heading.text()).toContain('no items')
+    it('Has the correct no-items form of heading', () => {
+      expect($heading.text().trim()).toBe('You have added no items')
     })
 
     it('has the default legend text', () => {
-      expect($legend.text()).toContain('Do you need to add another item?')
+      expect($legend.text().trim()).toBe('Do you need to add another item?')
     })
   })
 
@@ -28,25 +39,40 @@ describe('Add to a list', () => {
     const $heading = $('h1')
     const $rows = $('.hmrc-add-to-a-list__contents')
 
-    it('Uses "item" as the singular item name', () => {
-      expect($heading.text()).toContain('item')
-    })
-
-    it('Uses "1" as the count value', () => {
-      expect($heading.text()).toContain('1 item')
+    it('has the correct text for 1 item', () => {
+      expect($heading.text()).toBe('You have added 1 item')
     })
 
     it('Contains a list of 1 item', () => {
-      const $identifiers = $('span.hmrc-add-to-a-list__identifier', $rows)
-      const $changeLinks = $('span.hmrc-add-to-a-list__change', $rows)
-      const $removeLinks = $('span.hmrc-add-to-a-list__remove', $rows)
+      const listItems = getTableItems($)
 
       expect($rows.length).toBe(1)
-      expect($identifiers.text()).toContain('item one')
-      expect($changeLinks.text()).toContain('Change')
-      expect($removeLinks.text()).toContain('Remove')
-      expect($changeLinks.find('.govuk-visually-hidden').text()).toContain('Change item one')
-      expect($removeLinks.find('.govuk-visually-hidden').text()).toContain('Remove item one from the list')
+      expect(listItems.identifiers.text().trim()).toBe('item one')
+      expect(listItems.changeLinkText).toBe('Change')
+      expect(listItems.removeLinkText).toBe('Remove')
+      expect(listItems.ariaChangeText).toBe('Change item one')
+      expect(listItems.ariaRemoveText).toBe('Remove item one from the list')
+    })
+  })
+
+  describe('with one item in welsh', () => {
+    const $ = render('add-to-a-list', examples['single-generic-welsh-item'])
+    const $heading = $('h1')
+    const $rows = $('.hmrc-add-to-a-list__contents')
+
+    it('Has the correct singular welsh heading', () => {
+      expect($heading.text()).toBe('You have added - cy 1 item-cy')
+    })
+
+    it('Contains a list of 1 item', () => {
+      const listItems = getTableItems($)
+
+      expect($rows.length).toBe(1)
+      expect(listItems.identifiers.text().trim()).toBe('item one')
+      expect(listItems.changeLinkText).toBe('Change-cy')
+      expect(listItems.removeLinkText).toBe('Remove-cy')
+      expect(listItems.ariaChangeText).toBe('Change-cy item one')
+      expect(listItems.ariaRemoveText).toBe('Remove-cy item one from the list')
     })
   })
 
@@ -56,7 +82,6 @@ describe('Add to a list', () => {
     const $rows = $('.hmrc-add-to-a-list__contents')
     const $legend = $('fieldset legend')
     const $form = $('form')
-
     it('Uses "directors" as the plural item name', () => {
       expect($heading.text()).toContain('directors')
     })

--- a/src/components/hmrc-add-to-a-list/template.test.js
+++ b/src/components/hmrc-add-to-a-list/template.test.js
@@ -10,7 +10,11 @@ const getTableItems = ($) => {
   const $removeLinks = $('span.hmrc-add-to-a-list__remove', $rows)
 
   const listItems = {}
-  listItems.identifiers = $('span.hmrc-add-to-a-list__identifier', $rows)
+  listItems.identifiers = []
+  $('span.hmrc-add-to-a-list__identifier', $rows).each((index, element) => {
+    listItems.identifiers.push($(element).text().trim())
+  })
+  console.log(listItems.identifiers)
   listItems.changeLinkText = $changeLinks.find('[aria-hidden="true"]').eq(0).text().trim()
   listItems.removeLinkText = $removeLinks.find('[aria-hidden="true"]').eq(0).text().trim()
   listItems.ariaChangeText = $changeLinks.find('.govuk-visually-hidden').eq(0).text().trim()
@@ -47,7 +51,7 @@ describe('Add to a list', () => {
       const listItems = getTableItems($)
 
       expect($rows.length).toBe(1)
-      expect(listItems.identifiers.text().trim()).toBe('item one')
+      expect(listItems.identifiers[0]).toBe('item one')
       expect(listItems.changeLinkText).toBe('Change')
       expect(listItems.removeLinkText).toBe('Remove')
       expect(listItems.ariaChangeText).toBe('Change item one')
@@ -68,7 +72,7 @@ describe('Add to a list', () => {
       const listItems = getTableItems($)
 
       expect($rows.length).toBe(1)
-      expect(listItems.identifiers.text().trim()).toBe('item one')
+      expect(listItems.identifiers[0]).toBe('item one')
       expect(listItems.changeLinkText).toBe('Change-cy')
       expect(listItems.removeLinkText).toBe('Remove-cy')
       expect(listItems.ariaChangeText).toBe('Change-cy item one')
@@ -98,7 +102,10 @@ describe('Add to a list', () => {
       expect($rows.length).toBe(2)
       expect($identifiers.eq(0).text()).toContain('Director One')
       expect($changeLinks.eq(0).text()).toContain('Change Director One')
+      // TODO: add test for the change url
       expect($removeLinks.eq(0).text()).toContain('Remove Director One from the list')
+      // TODO: add test for the remove url
+
       expect($identifiers.eq(1).text()).toContain('Director Two')
       expect($changeLinks.eq(1).text()).toContain('Change Director Two')
       expect($removeLinks.eq(1).text()).toContain('Remove Director Two from the list')

--- a/src/components/hmrc-add-to-a-list/template.test.js
+++ b/src/components/hmrc-add-to-a-list/template.test.js
@@ -14,7 +14,6 @@ const getTableItems = ($) => {
   $('span.hmrc-add-to-a-list__identifier', $rows).each((index, element) => {
     listItems.identifiers.push($(element).text().trim())
   })
-  console.log(listItems.identifiers)
   listItems.changeLinkText = $changeLinks.find('[aria-hidden="true"]').eq(0).text().trim()
   listItems.removeLinkText = $removeLinks.find('[aria-hidden="true"]').eq(0).text().trim()
   listItems.ariaChangeText = $changeLinks.find('.govuk-visually-hidden').eq(0).text().trim()
@@ -30,11 +29,24 @@ describe('Add to a list', () => {
     const $legend = $('fieldset legend')
 
     it('Has the correct no-items form of heading', () => {
-      expect($heading.text().trim()).toBe('You have added no items')
+      expect($heading.text().trim()).toBe('You have not added any items')
     })
 
     it('has the default legend text', () => {
       expect($legend.text().trim()).toBe('Do you need to add another item?')
+    })
+  })
+
+  describe('with an empty list in welsh', () => {
+    const $ = render('add-to-a-list', examples['empty-list-welsh'])
+    const $heading = $('h1')
+    const $legend = $('fieldset legend')
+
+    it('Has the correct no-items form of heading in welsh', () => {
+      expect($heading.text().trim()).toBe('Nid ydych wedi ychwanegu unrhyw eitemau')
+    })
+    it('has the default legend text in welsh', () => {
+      expect($legend.text().trim()).toBe('Oes angen i chi ychwanegu eitem arall?')
     })
   })
 
@@ -65,7 +77,7 @@ describe('Add to a list', () => {
     const $rows = $('.hmrc-add-to-a-list__contents')
 
     it('Has the correct singular welsh heading', () => {
-      expect($heading.text()).toBe('You have added - cy 1 item-cy')
+      expect($heading.text()).toBe('Rydych wedi ychwanegu 1 eitem')
     })
 
     it('Contains a list of 1 item', () => {
@@ -73,10 +85,10 @@ describe('Add to a list', () => {
 
       expect($rows.length).toBe(1)
       expect(listItems.identifiers[0]).toBe('item one')
-      expect(listItems.changeLinkText).toBe('Change-cy')
-      expect(listItems.removeLinkText).toBe('Remove-cy')
-      expect(listItems.ariaChangeText).toBe('Change-cy item one')
-      expect(listItems.ariaRemoveText).toBe('Remove-cy item one from the list')
+      expect(listItems.changeLinkText).toBe('Newid')
+      expect(listItems.removeLinkText).toBe('Dileu')
+      expect(listItems.ariaChangeText).toBe('Newid item one')
+      expect(listItems.ariaRemoveText).toBe('Dileu’r item one o’r rhestr')
     })
   })
 
@@ -117,6 +129,46 @@ describe('Add to a list', () => {
 
     it('has an action set on the form', () => {
       expect($form.attr('action')).toBe('#add-director')
+    })
+  })
+
+  describe('with two unnamed items in Welsh', () => {
+    const $ = render('add-to-a-list', examples['mutltiple-generic-welsh-items'])
+    const $heading = $('h1')
+    const $rows = $('.hmrc-add-to-a-list__contents')
+    const $legend = $('fieldset legend')
+    const $form = $('form')
+    it('Uses "o eitemau" as the plural item name', () => {
+      expect($heading.text()).toBe('Rydych wedi ychwanegu 2 o eitemau')
+    })
+
+    it('Uses "2" as the count value', () => {
+      expect($heading.text()).toContain('2 o eitemau')
+    })
+
+    it('Contains a list of 2 items', () => {
+      const $identifiers = $('span.hmrc-add-to-a-list__identifier', $rows)
+      const $changeLinks = $('span.hmrc-add-to-a-list__change .govuk-visually-hidden', $rows)
+      const $removeLinks = $('span.hmrc-add-to-a-list__remove .govuk-visually-hidden', $rows)
+
+      expect($rows.length).toBe(2)
+      expect($identifiers.eq(0).text()).toContain('Eitem un')
+      expect($changeLinks.eq(0).text()).toContain('Newid Eitem un')
+      // TODO: add test for the change url
+      expect($removeLinks.eq(0).text()).toContain('Dileu’r Eitem un o’r rhestr')
+      // TODO: add test for the remove url
+
+      expect($identifiers.eq(1).text()).toContain('Eitem dau')
+      expect($changeLinks.eq(1).text()).toContain('Newid Eitem dau')
+      expect($removeLinks.eq(1).text()).toContain('Dileu’r Eitem dau o’r rhestr')
+    })
+
+    it('has the item type in the legend text', () => {
+      expect($legend.text()).toContain('Oes angen i chi ychwanegu eitem arall?')
+    })
+
+    it('has an action set on the form', () => {
+      expect($form.attr('action')).toBe('#addItem')
     })
   })
 })


### PR DESCRIPTION
Added Welsh translations for the content used in the Add to a list pattern.

Examples
1. An empty list at /components/add-to-a-list/empty-list-welsh/preview
![Screenshot from 2019-05-23 10-19-15](https://user-images.githubusercontent.com/234825/58241369-bdf97080-7d44-11e9-8c38-741cbe575805.png)

2. A single generic item at /components/add-to-a-list/single-generic-welsh-item/preview
![Screenshot from 2019-05-23 10-19-49](https://user-images.githubusercontent.com/234825/58241431-e2ede380-7d44-11e9-9f36-0dfd5fc4f9ea.png)

3. Multiple generic items at /components/add-to-a-list/mutltiple-generic-welsh-items/preview
![Screenshot from 2019-05-23 10-20-26](https://user-images.githubusercontent.com/234825/58241498-01ec7580-7d45-11e9-94ab-291da0da5624.png)

