### PR TITLE
Fix nesting of anchor and aria-current elements in language select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.9.1] - 2020-04-08
+
+### Fixed
+- Fix incorrect nesting of language selector styles
+
 ## [1.9.0] - 2020-04-08
 
 ### Added

--- a/src/components/language-select/_language-select.scss
+++ b/src/components/language-select/_language-select.scss
@@ -22,9 +22,9 @@
     height: 1em;
     border-right: .09375em solid  $govuk-text-colour;
   }
-}
 
-a,
-[aria-current] {
-  padding: .3125em;
+  a,
+  [aria-current] {
+    padding: .3125em;
+  }
 }


### PR DESCRIPTION
<!-- Provide a short summary of the issue in the Title above. -->

<!-- Make sure your work follows to our CONTRIBUTING guidelines. -->
<!-- There's a link to them above. -->

## Problem
<!-- What problem does the pull request solve? Why is this change required? -->
<!-- If it fixes an open issue, please link to the issue or add: Fixes #<issue_number> -->
The styles for the links in the `language-select` component were being applied globally to all `a` elements and elements with the attribute `aria-current`.

### Example Screenshot
<!-- Add an image or gif to help illustrate the point. -->
![image](https://user-images.githubusercontent.com/3120611/79456382-54cabd80-7fe6-11ea-9e83-e1a7360a3654.png)

## Solution
<!-- Describe your changes -->
The SCSS selector was moved inside the the segment specific to the language selector so that the new compiled CSS selector is `.hmrc-language-select__list-item a, .hmrc-language-select__list-item [aria-current]`.

### Example Screenshot
<!-- If possible, add an image or gif of what's changed. -->
![image](https://user-images.githubusercontent.com/3120611/79456487-83489880-7fe6-11ea-95ec-88b9e665a998.png)
