### PR TITLE
Remove compatibility check until mechanism can be fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.10.1] - 2020-04-22
+
+### Fixed
+- Fix compatibility check (by removing for now)
+
 ## [1.10.0] - 2020-04-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.10.1] - 2020-04-22
 
 ### Fixed
-- Fix compatibility check (by removing for now)
+- Fix compatibility check - this is a temporary workaround to avoid throwing an exception with the version can't be found. 
 
 ## [1.10.0] - 2020-04-21
 

--- a/check-compatibility.js
+++ b/check-compatibility.js
@@ -40,10 +40,15 @@ const checkCompatibility = (version, host = 'prototype-kit') => {
   const getMatchableVersion = (v) => parseFloat(v).toFixed(1)
 
   const installingHmrcVersion = String(getMatchableVersion(hmrcFrontendVersion))
-  const latestKnownHost = compatibility[installingHmrcVersion][host][0]
+  const compatibilityMatch = compatibility[installingHmrcVersion]
+  if (!compatibilityMatch) {
+    console.log('The version couldn\'t be matched, compatibility couldn\'t be checked')
+    process.exit(0)
+  }
+  const latestKnownHost = compatibilityMatch[host][0]
   const hostVersion = String(getMatchableVersion(version))
 
-  const compatible = compatibility[installingHmrcVersion][host].includes(hostVersion) || parseFloat(hostVersion) > parseFloat(latestKnownHost)
+  const compatible = compatibilityMatch[host].includes(hostVersion) || parseFloat(hostVersion) > parseFloat(latestKnownHost)
   let alternativeVersion = !compatible && Object.keys(compatibility)
     .find(hmrcVersion => compatibility[hmrcVersion][host].includes(hostVersion))
 

--- a/check-compatibility.js
+++ b/check-compatibility.js
@@ -42,7 +42,7 @@ const checkCompatibility = (version, host = 'prototype-kit') => {
   const installingHmrcVersion = String(getMatchableVersion(hmrcFrontendVersion))
   const compatibilityMatch = compatibility[installingHmrcVersion]
   if (!compatibilityMatch) {
-    console.log('The version couldn\'t be matched, compatibility couldn\'t be checked')
+    console.error('The version couldn\'t be matched, compatibility couldn\'t be checked')
     process.exit(0)
   }
   const latestKnownHost = compatibilityMatch[host][0]

--- a/check-compatibility.js
+++ b/check-compatibility.js
@@ -42,7 +42,7 @@ const checkCompatibility = (version, host = 'prototype-kit') => {
   const installingHmrcVersion = String(getMatchableVersion(hmrcFrontendVersion))
   const compatibilityMatch = compatibility[installingHmrcVersion]
   if (!compatibilityMatch) {
-    console.error('The version couldn\'t be matched, compatibility couldn\'t be checked')
+    console.warn('The version couldn\'t be matched, compatibility couldn\'t be checked')
     process.exit(0)
   }
   const latestKnownHost = compatibilityMatch[host][0]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "standard && gulp test && gulp copy-assets && jest src",
     "test:compatibility": "jest __tests__/check-compatibility.test.js",
     "test:build:package": "jest tasks/gulp/__tests__/after-build-package.test.js",
-    "test:build:dist": "jest tasks/gulp/__tests__/after-build-dist.test.js"
+    "test:build:dist": "jest tasks/gulp/__tests__/after-build-dist.test.js",
+    "preinstall": "node check-compatibility.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",
@@ -9,8 +9,7 @@
     "test": "standard && gulp test && gulp copy-assets && jest src",
     "test:compatibility": "jest __tests__/check-compatibility.test.js",
     "test:build:package": "jest tasks/gulp/__tests__/after-build-package.test.js",
-    "test:build:dist": "jest tasks/gulp/__tests__/after-build-dist.test.js",
-    "preinstall": "node check-compatibility.js"
+    "test:build:dist": "jest tasks/gulp/__tests__/after-build-dist.test.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The existing logic uses parseFloat to compare major and minor versions. E.g. there is a check that looks at parseFloat("1.10") = 1.1 < 1.10