### PR TITLE
Fix language toggle

### DIFF
--- a/src/components/language-select/template.njk
+++ b/src/components/language-select/template.njk
@@ -10,7 +10,7 @@
           lang="cy"
           rel="alternate"
           class="govuk-link"
-          data-journey-click="link - click:lang-select:English">
+          data-journey-click="link - click:lang-select:Cymraeg">
           <span class="govuk-visually-hidden">Newid yr iaith ir Gymraeg</span>
           <span aria-hidden="true">Cymraeg</span>
         </a>
@@ -28,7 +28,7 @@
           lang="en"
           rel="alternate"
           class="govuk-link"
-          data-journey-click="link - click:lang-select:Cymraeg">
+          data-journey-click="link - click:lang-select:English">
           <span class="govuk-visually-hidden">Change the language to English</span>
           <span aria-hidden="true">English</span>
         </a>

--- a/src/components/language-select/template.test.js
+++ b/src/components/language-select/template.test.js
@@ -25,7 +25,7 @@ describe('New Tab Link', () => {
       expect($component.attr('hreflang')).toEqual('cy')
       expect($component.attr('lang')).toEqual('cy')
       expect($component.attr('href')).toEqual(examples.default.cy.href)
-      expect($component.data('journeyClick')).toEqual('link - click:lang-select:English')
+      expect($component.data('journeyClick')).toEqual('link - click:lang-select:Cymraeg')
 
       expect($component.find('.govuk-visually-hidden').eq(0).text()).toEqual('Newid yr iaith ir Gymraeg')
       expect($component.find('[aria-hidden="true"]').eq(0).text()).toEqual('Cymraeg')
@@ -44,7 +44,7 @@ describe('New Tab Link', () => {
       expect($component.attr('hreflang')).toEqual('en')
       expect($component.attr('lang')).toEqual('en')
       expect($component.attr('href')).toEqual(examples.welsh.en.href)
-      expect($component.data('journeyClick')).toEqual('link - click:lang-select:Cymraeg')
+      expect($component.data('journeyClick')).toEqual('link - click:lang-select:English')
 
       expect($component.find('.govuk-visually-hidden').eq(0).text()).toEqual('Change the language to English')
       expect($component.find('[aria-hidden="true"]').eq(0).text()).toEqual('English')


### PR DESCRIPTION
The data-journey-select attributes used for analytics were the wrong way round.