### PR TITLE
Standardising null and empty arrays

### DIFF
--- a/config/paths.json
+++ b/config/paths.json
@@ -13,6 +13,6 @@
   "packageTest": "__tests__/packageTest",
   "ports": {
     "app": 3000,
-    "test": 8888
+    "test": 8887
   }
 }

--- a/config/paths.json
+++ b/config/paths.json
@@ -13,6 +13,6 @@
   "packageTest": "__tests__/packageTest",
   "ports": {
     "app": 3000,
-    "test": 8887
+    "test": 8888
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1007,9 +1007,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true
         },
         "https-proxy-agent": {
@@ -1032,9 +1032,9 @@
           }
         },
         "mime": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
           "dev": true
         },
         "mime-db": {
@@ -8861,9 +8861,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true,
           "optional": true
         }
@@ -11170,9 +11170,9 @@
       "dev": true
     },
     "portfinder": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
-      "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
+      "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
       "dev": true,
       "requires": {
         "async": "^2.6.2",

--- a/src/components/add-to-a-list/template.test.js
+++ b/src/components/add-to-a-list/template.test.js
@@ -171,4 +171,19 @@ describe('Add to a list', () => {
       expect($form.attr('action')).toBe('#addItem')
     })
   })
+
+  describe('Empty, null and missing itemLists', () => {
+    function overrideItemList (itemList) {
+      const params = {...examples.default}
+      params.itemList = itemList
+      return params
+    }
+
+    it('should have the same output for all versions of no items being provided', () => {
+      const outputs = [undefined, null, []].map(itemList => render('add-to-a-list', overrideItemList(itemList)).html())
+
+      expect(outputs[0]).toEqual(outputs[1])
+      expect(outputs[0]).toEqual(outputs[2])
+    })
+  })
 })

--- a/src/components/header/header.yaml
+++ b/src/components/header/header.yaml
@@ -10,11 +10,11 @@ params:
 - name: productName
   type: string
   required: false
-  description: Header title that is placed next to GOV.UK. Used for product names (i.e. Pay, Verify)
+  description: Product name, used when the product name follows on directly from ‘GOV.UK’. For example, GOV.UK Pay or GOV.UK Design System. In most circumstances, you should use serviceName.
 - name: serviceName
   type: string
   required: false
-  description: Header title that is placed next to GOV.UK. Used for product names (i.e. Pay, Verify)
+  description: The name of your service, included in the header.
 - name: serviceUrl
   type: string
   required: false
@@ -27,7 +27,11 @@ params:
   - name: text
     type: string
     required: false
-    description: Text of the navigation item.
+    description: Text for the navigation item. If `html` is provided, the `text` argument will be ignored.
+  - name: html
+    type: string
+    required: false
+    description: HTML for the navigation item. If `html` is provided, the `text` argument will be ignored.
   - name: href
     type: string
     required: false
@@ -84,17 +88,16 @@ accessibilityCriteria: |
 examples:
 - name: default
   description: The standard header as used on information pages on GOV.UK
-  language: en
   data:
     {}
 
-- name: with-service-name
+- name: with service name
   description: If your service is more than a few pages long, you can help users understand where they are by adding the service name.
   data:
     serviceName: Service Name
     serviceUrl: '/components/header'
 
-- name: with-navigation
+- name: with navigation
   data:
     navigation:
       - href: '#1'
@@ -107,7 +110,7 @@ examples:
       - href: '#4'
         text: Navigation item 4
 
-- name: with-service-name-and-navigation
+- name: with service name and navigation
   description: If you need to include basic navigation, contact or account management links.
   data:
     serviceName: Service Name
@@ -123,7 +126,7 @@ examples:
       - href: '#4'
         text: Navigation item 4
 
-- name: with-large-navigation
+- name: with large navigation
   description: An edge case example with a large number of navitation items with long names used to test wrapping
   data:
     navigation:
@@ -160,13 +163,18 @@ examples:
       - href: '/browse/working'
         text: Working, jobs and pensions
 
-- name: full-width
+- name: with product name
+  data:
+    navigationClasses: govuk-header__navigation--end
+    productName: Product Name
+
+- name: full width
   data:
     containerClasses: govuk-header__container--full-width
     navigationClasses: govuk-header__navigation--end
     productName: Product Name
 
-- name: full-width-with-navigation
+- name: full width with navigation
   data:
     containerClasses: govuk-header__container--full-width
     navigationClasses: govuk-header__navigation--end
@@ -180,19 +188,32 @@ examples:
       - href: '#3'
         text: Navigation item 3
 
-- name: sign-out-link
+- name: navigation item with html
+  data:
+    serviceName: Service Name
+    serviceUrl: '/components/header'
+    navigation:
+      - href: '#1'
+        html: <em>Navigation item 1</em>
+        active: true
+      - href: '#2'
+        html: <em>Navigation item 2</em>
+      - href: '#3'
+        html: <em>Navigation item 3</em>
+
+- name: sign out link
   data:
     serviceName: Example Service
     signOutHref: /sign-out
 
-- name: sign-out-link-in-welsh
+- name: sign out link in welsh
   description: This puts the signout link into the header and sets the whole header to be welsh.  At the time of writing the language only affects the signout text.
   data:
     serviceName: Gwasanaeth enghreifftiol
     language: cy
     signOutHref: /sign-out
 
-- name: with-language-toggle-english
+- name: with language toggle english
   data:
     serviceName: Example Service
     language: en
@@ -202,7 +223,7 @@ examples:
       cy:
         href: "/components/header/with-language-toggle-welsh/preview"
 
-- name: with-language-toggle-welsh
+- name: with language toggle welsh
   data:
     serviceName: Gwasanaeth enghreifftiol
     language: cy
@@ -212,7 +233,7 @@ examples:
       cy:
         href: "/components/header/with-language-toggle-welsh/preview"
 
-- name: with-hmrc-banner-english
+- name: with hmrc banner english
   data:
     serviceName: Service with HMRC Banner
     language: en
@@ -223,7 +244,7 @@ examples:
       cy:
         href: "/components/header/with-hmrc-banner-welsh/preview"
 
-- name: with-hmrc-banner-welsh
+- name: with hmrc banner welsh
   data:
     serviceName: Gwasanaeth gyda Banner CThEM
     language: cy

--- a/src/components/header/template.njk
+++ b/src/components/header/template.njk
@@ -2,12 +2,12 @@
 {% from "../banner/macro.njk" import hmrcBanner %}
 
 <header class="govuk-header hmrc-header {{ params.classes if params.classes }} {{ 'hmrc-header--with-additional-navigation' if params.signOutHref or params.languageToggle }}" role="banner" data-module="header"
-        {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+        {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <div class="govuk-header__container {{ params.containerClasses | default('govuk-width-container') }}">
     <div class="govuk-header__logo">
       <a href="{{ params.homepageUrl | default('/') }}" class="govuk-header__link govuk-header__link--homepage">
         <span class="govuk-header__logotype">
-          {# We use an inline SVG for the crown so that we can cascade the
+          {#- We use an inline SVG for the crown so that we can cascade the
           currentColor into the crown whilst continuing to support older browsers
           which do not support external SVGs without a Javascript polyfill. This
           adds approximately 1kb to every page load.
@@ -20,19 +20,19 @@
           treat it as an interactive element - without this it will be
           'focusable' when using the keyboard to navigate. #}
           <svg
-            role="presentation"
+            aria-hidden="true"
             focusable="false"
             class="govuk-header__logotype-crown"
             xmlns="http://www.w3.org/2000/svg"
             viewbox="0 0 132 97"
-            height="32"
+            height="30"
             width="36"
           >
             <path
               fill="currentColor" fill-rule="evenodd"
               d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
             ></path>
-            {# Fallback PNG image for older browsers.
+            {#- Fallback PNG image for older browsers.
 
             The <image> element is a valid SVG element. In SVG, you would specify
             the URL of the image file with the xlink:href – as we don't reference an
@@ -42,8 +42,7 @@
 
             In other browsers <image> is synonymous for the <img> tag and will be
             interpreted as such, displaying the fallback image. #}
-            <image src="{{ params.assetsPath | default('/assets/images') }}/govuk-logotype-crown.png"
-                   class="govuk-header__logotype-crown-fallback-image"></image>
+            <image src="{{ params.assetsPath | default('/assets/images') }}/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
           </svg>
           <span class="govuk-header__logotype-text">
             GOV.UK
@@ -56,38 +55,29 @@
         {% endif %}
       </a>
     </div>
-
-    {% if params.serviceName or params.navigation or params.signOutHref or params.languageToggle %}
+    {% if params.serviceName or params.navigation  %}
     <div class="govuk-header__content">
-      {% if params.serviceName %}
-        <a href="{{ params.serviceUrl }}" class="govuk-header__link govuk-header__link--service-name">
-          {{ params.serviceName }}
-        </a>
-      {% endif %}
-
-      {% if params.navigation %}
-        <button type="button" role="button" class="govuk-header__menu-button js-header-toggle"
-                aria-controls="navigation"
-                aria-label="Show or hide Top Level Navigation">Menu
-        </button>
-        <nav>
-          <ul id="navigation"
-              class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}"
-              aria-label="Top Level Navigation">
-            {% for item in params.navigation %}
-              {% if item.href and item.text %}
-                <li class="govuk-header__navigation-item{{ ' govuk-header__navigation-item--active' if item.active }}">
-                  <a class="govuk-header__link"
-                     href="{{ item.href }}"{% for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
-                  >
-                  {{ item.text }}
-                  </a>
-                </li>
-              {% endif %}
-            {% endfor %}
-          </ul>
-        </nav>
-      {% endif %}
+    {% if params.serviceName %}
+    <a href="{{ params.serviceUrl }}" class="govuk-header__link govuk-header__link--service-name">
+      {{ params.serviceName }}
+    </a>
+    {% endif %}
+    {% if params.navigation %}
+    <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+    <nav>
+      <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}" aria-label="Top Level Navigation">
+        {% for item in params.navigation %}
+          {% if item.href and (item.text or item.html) %}
+            <li class="govuk-header__navigation-item{{ ' govuk-header__navigation-item--active' if item.active }}">
+              <a class="govuk-header__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+                {{ item.html | safe if item.html else item.text }}
+              </a>
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </nav>
+    {% endif %}
 
       {% if params.signOutHref %}
         <nav class="hmrc-sign-out-nav">
@@ -110,7 +100,7 @@
         </nav>
       {% endif %}
     </div>
-  {% endif %}
+    {% endif %}
   </div>
 </header>
 <div class="govuk-width-container">

--- a/src/components/header/template.njk
+++ b/src/components/header/template.njk
@@ -55,14 +55,14 @@
         {% endif %}
       </a>
     </div>
-    {% if params.serviceName or params.navigation  %}
+    {% if params.serviceName or params.navigation | length %}
     <div class="govuk-header__content">
     {% if params.serviceName %}
     <a href="{{ params.serviceUrl }}" class="govuk-header__link govuk-header__link--service-name">
       {{ params.serviceName }}
     </a>
     {% endif %}
-    {% if params.navigation %}
+    {% if params.navigation | length %}
     <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
     <nav>
       <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}" aria-label="Top Level Navigation">

--- a/src/components/header/template.njk
+++ b/src/components/header/template.njk
@@ -55,7 +55,7 @@
         {% endif %}
       </a>
     </div>
-    {% if params.serviceName or params.navigation | length %}
+    {% if params.serviceName or params.navigation | length or params.signOutHref or params.languageToggle %}
     <div class="govuk-header__content">
     {% if params.serviceName %}
     <a href="{{ params.serviceUrl }}" class="govuk-header__link govuk-header__link--service-name">

--- a/src/components/header/template.test.js
+++ b/src/components/header/template.test.js
@@ -1,0 +1,178 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-env jest */
+
+const axe = require('../../../lib/axe-helper')
+
+const { render, getExamples } = require('../../../lib/jest-helpers')
+
+const examples = getExamples('header')
+
+describe('header', () => {
+  it('passes accessibility tests', async () => {
+    const $ = render('header', examples.default)
+
+    const results = await axe($.html())
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has a role of `banner`', () => {
+    const $ = render('header', {})
+
+    const $component = $('.govuk-header')
+    expect($component.attr('role')).toEqual('banner')
+  })
+
+  it('renders attributes correctly', () => {
+    const $ = render('header', {
+      attributes: {
+        'data-test-attribute': 'value',
+        'data-test-attribute-2': 'value-2'
+      }
+    })
+
+    const $component = $('.govuk-header')
+    expect($component.attr('data-test-attribute')).toEqual('value')
+    expect($component.attr('data-test-attribute-2')).toEqual('value-2')
+  })
+
+  it('renders classes', () => {
+    const $ = render('header', {
+      classes: 'app-header--custom-modifier'
+    })
+
+    const $component = $('.govuk-header')
+    expect($component.hasClass('app-header--custom-modifier')).toBeTruthy()
+  })
+
+  it('renders custom container classes', () => {
+    const $ = render('header', {
+      containerClasses: 'app-width-container'
+    })
+
+    const $component = $('.govuk-header')
+    const $container = $component.find('.govuk-header__container')
+
+    expect($container.hasClass('app-width-container')).toBeTruthy()
+  })
+
+  it('renders home page URL', () => {
+    const $ = render('header', {
+      homepageUrl: '/'
+    })
+
+    const $component = $('.govuk-header')
+    const $homepageLink = $component.find('.govuk-header__link--homepage')
+    expect($homepageLink.attr('href')).toEqual('/')
+  })
+
+  describe('with product name', () => {
+    it('renders product name', () => {
+      const $ = render('header', examples['full width'])
+
+      const $component = $('.govuk-header')
+      const $productName = $component.find('.govuk-header__product-name')
+      expect($productName.text().trim()).toEqual('Product Name')
+    })
+  })
+
+  describe('with service name', () => {
+    it('renders service name', () => {
+      const $ = render('header', examples['with service name'])
+
+      const $component = $('.govuk-header')
+      const $serviceName = $component.find('.govuk-header__link--service-name')
+      expect($serviceName.text().trim()).toEqual('Service Name')
+    })
+  })
+
+  describe('with navigation', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('header', examples['with navigation'])
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('renders navigation', () => {
+      const $ = render('header', examples['with navigation'])
+
+      const $component = $('.govuk-header')
+      const $list = $component.find('ul.govuk-header__navigation')
+      const $items = $list.find('li.govuk-header__navigation-item')
+      const $firstItem = $items.find('a.govuk-header__link:first-child')
+      expect($items.length).toEqual(4)
+      expect($firstItem.attr('href')).toEqual('#1')
+      expect($firstItem.text()).toContain('Navigation item 1')
+    })
+
+    it('renders navigation item with html', () => {
+      const $ = render('header', {
+        navigation: [
+          {
+            href: '#1',
+            html: '<em>Nav item</em>'
+          }
+        ]
+      })
+
+      const $navigationLink = $('.govuk-header__navigation-item a')
+      expect($navigationLink.html()).toContain('<em>Nav item</em>')
+    })
+
+    it('renders navigation item anchor with attributes', () => {
+      const $ = render('header', {
+        navigation: [
+          {
+            text: 'Item',
+            href: '/link',
+            attributes: {
+              'data-attribute': 'my-attribute',
+              'data-attribute-2': 'my-attribute-2'
+            }
+          }
+        ]
+      })
+
+      const $navigationLink = $('.govuk-header__navigation-item a')
+      expect($navigationLink.attr('data-attribute')).toEqual('my-attribute')
+      expect($navigationLink.attr('data-attribute-2')).toEqual('my-attribute-2')
+    })
+    describe('menu button', () => {
+      it('has an explicit type="button" so it does not act as a submit button', () => {
+        const $ = render('header', examples['with navigation'])
+
+        const $button = $('.govuk-header__menu-button')
+
+        expect($button.attr('type')).toEqual('button')
+      })
+    })
+  })
+
+  describe('SVG logo', () => {
+    const $ = render('header', {})
+    const $svg = $('.govuk-header__logotype-crown')
+
+    it('sets focusable="false" so that IE does not treat it as an interactive element', () => {
+      expect($svg.attr('focusable')).toEqual('false')
+    })
+
+    it('sets aria-hidden="true" so that it is ignored by assistive technologies', () => {
+      expect($svg.attr('aria-hidden')).toEqual('true')
+    })
+
+    describe('fallback PNG', () => {
+      const $fallbackImage = $('.govuk-header__logotype-crown-fallback-image')
+
+      it('uses the <image> tag which is a valid SVG element', () => {
+        expect($fallbackImage[0].tagName).toEqual('image')
+      })
+
+      it('sets a blank xlink:href to prevent IE from downloading both the SVG and the PNG', () => {
+        // Cheerio converts xhref to href - https://github.com/cheeriojs/cheerio/issues/1101
+        expect($fallbackImage.attr('href')).toEqual('')
+      })
+    })
+  })
+})

--- a/src/components/header/template.test.js
+++ b/src/components/header/template.test.js
@@ -139,6 +139,18 @@ describe('header', () => {
       expect($navigationLink.attr('data-attribute')).toEqual('my-attribute')
       expect($navigationLink.attr('data-attribute-2')).toEqual('my-attribute-2')
     })
+    it('renders navigation the same with different empty values', () => {
+      function overrideItemList (navigation) {
+        const params = {...examples.default}
+        params.navigation = navigation
+        return params
+      }
+
+      const outputs = [undefined, null, []].map(itemList => render('header', overrideItemList(itemList)).html())
+
+      expect(outputs[0]).toEqual(outputs[1])
+      expect(outputs[0]).toEqual(outputs[2])
+    })
     describe('menu button', () => {
       it('has an explicit type="button" so it does not act as a submit button', () => {
         const $ = render('header', examples['with navigation'])


### PR DESCRIPTION
This is the HMRC equivalent of https://github.com/alphagov/govuk-frontend/pull/1638 which is best explained in this issue https://github.com/alphagov/govuk-frontend/issues/1618.

This PR includes an update of the `header` component which had fallen out of sync with `govuk-frontend`.  No other changes were required in the production code but I've added a test to make sure the output remains the same in these cases where `itemList` is used in `add-to-a-list`.