### PR TITLE
GDS Transport font for status tag in task list

### DIFF
--- a/src/components/status-tags-in-task-list-pages/_status-tags-in-task-list-pages.scss
+++ b/src/components/status-tags-in-task-list-pages/_status-tags-in-task-list-pages.scss
@@ -5,7 +5,7 @@
 .hmrc-status-tag {
   float: right;
   color: $govuk-text-colour;
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
 }
 


### PR DESCRIPTION
The font for the status tags in the [example for the Status tags in task list pages pattern](https://github.com/hmrc/design-system/blob/master/src/examples/status-tags-in-task-list-pages/example/index.njk) is falling back to Arial, rather than GDS Transport.

The `.hmrc-status-tag` class uses this font stack:

```css
font-family: "nta", Arial, sans-serif;
```

It looks like this should be as follows, which would be in line with the rest of the page:

```css
font-family: "GDS Transport", Arial, sans-serif;
```
