### PR TITLE
Timeout Dialog: allow users to set a different URL for timeouts than manual sign outs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.16.0] - 2020-09-10
+
+### Changed
+
+- `hmrcTimeoutDialog` Allow users to set a different URL for timeouts than manual sign outs
+
 ## [1.15.3] - 2020-08-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "1.15.1",
+  "version": "1.15.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "1.15.3",
+  "version": "1.16.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/timeout-dialog/template.njk
+++ b/src/components/timeout-dialog/template.njk
@@ -6,6 +6,7 @@
       data-countdown="{{ params.countdown }}"
       data-keep-alive-url="{{ params.keepAliveUrl }}"
       data-sign-out-url="{{ params.signOutUrl }}"
+      data-timeout-url="{{ params.timeoutUrl }}"
       data-title="{{ params.title }}"
       data-message="{{ params.message }}"
       data-message-suffix="{{ params.messageSuffix }}"

--- a/src/components/timeout-dialog/timeout-dialog.js
+++ b/src/components/timeout-dialog/timeout-dialog.js
@@ -58,6 +58,7 @@ function TimeoutDialog ($module) {
       countdown: validate.int(lookupData('data-countdown')),
       keepAliveUrl: validate.string(lookupData('data-keep-alive-url')),
       signOutUrl: validate.string(lookupData('data-sign-out-url')),
+      timeoutUrl: validate.string(lookupData('data-timeout-url')),
       title: validate.string(lookupData('data-title')),
       message: validate.string(lookupData('data-message')),
       messageSuffix: validate.string(lookupData('data-message-suffix')),
@@ -68,6 +69,9 @@ function TimeoutDialog ($module) {
         lookupData('data-sign-out-button-text')
       )
     }
+
+    // Default timeoutUrl to signOutUrl if not set
+    options.timeoutUrl = options.timeoutUrl || options.signOutUrl
 
     validateInput(options)
     settings = mergeOptionsWithDefaults(options, localisedDefaults)
@@ -255,7 +259,7 @@ function TimeoutDialog ($module) {
       var counter = getSecondsRemaining()
       updateCountdown(counter, $countdownElement)
       if (counter <= 0) {
-        signOut()
+        timeout()
       }
       currentTimer = window.setTimeout(runUpdate, getNextTimeout())
     }
@@ -276,6 +280,10 @@ function TimeoutDialog ($module) {
 
   function signOut () {
     RedirectHelper.redirectToUrl(settings.signOutUrl)
+  }
+
+  function timeout () {
+    RedirectHelper.redirectToUrl(settings.timeoutUrl)
   }
 
   function cleanup () {

--- a/src/components/timeout-dialog/timeout-dialog.test.js
+++ b/src/components/timeout-dialog/timeout-dialog.test.js
@@ -267,7 +267,8 @@ describe('/components/timeout-dialog', () => {
         'data-message-suffix': 'My message suffix.',
         'data-keep-alive-button-text': 'KEEP alive',
         'data-sign-out-button-text': 'sign OUT',
-        'data-sign-out-url': '/mySignOutUrl.html'
+        'data-sign-out-url': '/mySignOutUrl.html',
+        'data-timeout-url': '/myTimeoutUrl.html'
       })
       pretendSecondsHavePassed(780)
     })
@@ -416,7 +417,8 @@ describe('/components/timeout-dialog', () => {
         'data-timeout': 130,
         'data-countdown': 120,
         'data-message': 'time:',
-        'data-sign-out-url': 'logout'
+        'data-sign-out-url': 'signout',
+        'data-timeout-url': 'timeout'
       })
 
       pretendSecondsHavePassed(10)
@@ -451,7 +453,7 @@ describe('/components/timeout-dialog', () => {
       expect(getAudibleCountText()).toEqual('time: 20 seconds.')
       pretendSecondsHavePassed(1)
 
-      expect(redirectHelper.redirectToUrl).toHaveBeenCalledWith('logout')
+      expect(redirectHelper.redirectToUrl).toHaveBeenCalledWith('timeout')
       expect(getVisualCountText()).toEqual('time: -1 seconds.')
       expect(getAudibleCountText()).toEqual('time: 20 seconds.')
       pretendSecondsHavePassed(1)
@@ -459,12 +461,23 @@ describe('/components/timeout-dialog', () => {
       expect(getVisualCountText()).toEqual('time: -2 seconds.')
       expect(getAudibleCountText()).toEqual('time: 20 seconds.')
     })
+    it('should default redirectToUrl to data-sign-out-url if data-timeout-url is not set', function () {
+      setupDialog({
+        'data-timeout': 130,
+        'data-countdown': 120,
+        'data-message': 'time:',
+        'data-sign-out-url': 'logout'
+      })
+      pretendSecondsHavePassed(131)
+      expect(redirectHelper.redirectToUrl).toHaveBeenCalledWith('logout')
+    })
     it('should have an audio countdown which counts the last minute in 20 second decrements', function () {
       setupDialog({
         'data-timeout': 70,
         'data-countdown': 65,
         'data-message': 'time:',
-        'data-sign-out-url': 'logout'
+        'data-sign-out-url': 'signout',
+        'data-timeout-url': 'timeout'
       })
 
       pretendSecondsHavePassed(10)
@@ -505,7 +518,8 @@ describe('/components/timeout-dialog', () => {
         'data-timeout': 130,
         'data-countdown': 120,
         'data-message': 'Welsh, time:',
-        'data-sign-out-url': 'logout'
+        'data-sign-out-url': 'signout',
+        'data-timeout-url': 'timeout'
       })
 
       pretendSecondsHavePassed(10)
@@ -540,7 +554,7 @@ describe('/components/timeout-dialog', () => {
       expect(getAudibleCountText()).toEqual('Welsh, time: 20 eiliad.')
       pretendSecondsHavePassed(1)
 
-      expect(redirectHelper.redirectToUrl).toHaveBeenCalledWith('logout')
+      expect(redirectHelper.redirectToUrl).toHaveBeenCalledWith('timeout')
       expect(getVisualCountText()).toEqual('Welsh, time: -1 eiliad.')
       expect(getAudibleCountText()).toEqual('Welsh, time: 20 eiliad.')
       pretendSecondsHavePassed(1)
@@ -623,7 +637,8 @@ describe('/components/timeout-dialog', () => {
         'data-timeout': 130,
         'data-countdown': 50,
         'data-message': 'Remaining time is',
-        'data-sign-out-url': 'logout'
+        'data-sign-out-url': 'signout',
+        'data-timeout-url': 'timeout'
       })
       const lowestAudibleCount = 'Remaining time is 20 seconds.'
 
@@ -651,7 +666,7 @@ describe('/components/timeout-dialog', () => {
       expect(getAudibleCountText()).toEqual(lowestAudibleCount)
       pretendSecondsHavePassed(1)
 
-      expect(redirectHelper.redirectToUrl).toHaveBeenCalledWith('logout')
+      expect(redirectHelper.redirectToUrl).toHaveBeenCalledWith('timeout')
       expect(getVisualCountText()).toEqual('Remaining time is -1 seconds.')
       expect(getAudibleCountText()).toEqual(lowestAudibleCount)
       pretendSecondsHavePassed(1)
@@ -666,7 +681,8 @@ describe('/components/timeout-dialog', () => {
         'data-timeout': 130,
         'data-countdown': 50,
         'data-message': 'time:',
-        'data-sign-out-url': 'logout'
+        'data-sign-out-url': 'signout',
+        'data-timeout-url': 'timeout'
       })
 
       pretendSecondsHavePassed(80)


### PR DESCRIPTION
Hi,

This pull request will allow users of the Timeout Dialog to set different url to redirect to on timeout than the URL for clicking the delete data / sign out link.

It should be none breaking, as if you don't set a timeout-url it will default to the sign-out-url, retaining the original functionality.

## Use case
Session timeouts are handled internally in our framework, so if you request a page after your session is timed out you are redirected to `/session-timeout` with a referrer querystring containing the URL of the page you requested (we use this in GA to see which pages people time out on).

Using this component I have to redirect to a `/end-session` URL to clear the session to makes the link work, but I lose the benefit of the querystring on the session timeout page. This is because it will also redirect to `/end-session`, then redirect to session-timeout with `/end-session` as the referrer.

Another issue is that since both the timeout and link will focibly kill the session, if the session is being refreshed in a separate tab, the fogotten tab will eventually timeout and kill a session for a user that wouldn't have otherwise reached it's expiry time.

However, if I set the timeout URL to redirect to the page it's on the session timeout middleware will kick in showing a timeout page with the approrpriate referrer URL and if the session is being maintained in another tab the page will just refresh every 30 minutes and not kill an active session. The sign out link however can continue to point to a URL that will forcibly end the session.