### PR TITLE
issue-89 fixed status tag alignment on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- issue where status tags weren't left aligning at mobile widths
+
 ## [1.17.0] - 2020-09-21
 
 ### Changed

--- a/src/components/status-tags-in-task-list-pages/_status-tags-in-task-list-pages.scss
+++ b/src/components/status-tags-in-task-list-pages/_status-tags-in-task-list-pages.scss
@@ -3,10 +3,18 @@
 // Custom styles
 
 .hmrc-status-tag {
-  float: right;
   color: $govuk-text-colour;
   font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($from: 450px) {
+    float: right;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
 }
 
 .app-task-list__items {


### PR DESCRIPTION
This fixes issue https://github.com/hmrc/hmrc-frontend/issues/89 on mobile width devices where status tags aren't left aligned. Some changes were made based on gov.uk task list styles at https://github.com/alphagov/govuk-prototype-kit/blob/master/app/assets/sass/patterns/_task-list.scss