### PR TITLE
Welsh language footer

### DIFF
--- a/src/components/footer/README.md
+++ b/src/components/footer/README.md
@@ -1,0 +1,15 @@
+# Footer
+
+## Installation
+
+See the [main README quick start guide](https://github.com/alphagov/govuk-frontend#quick-start) for how to install this component.
+
+## Guidance and Examples
+
+Find out when to use the footer component in your service in the [GOV.UK Design System](https://design-system.service.gov.uk/components/footer).
+
+## Component options
+
+Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
+
+See [options table](https://design-system.service.gov.uk/components/footer/#options-footer-example) for details.

--- a/src/components/footer/footer.yaml
+++ b/src/components/footer/footer.yaml
@@ -320,6 +320,10 @@ examples:
 - name: with empty meta
   data:
     meta: {}
+- name: with empty meta in Welsh
+  data:
+    language: cy
+    meta: {}
 - name: with empty meta items
   data:
     meta:

--- a/src/components/footer/footer.yaml
+++ b/src/components/footer/footer.yaml
@@ -1,0 +1,356 @@
+params:
+- name: meta
+  type: object
+  required: false
+  description: Object containing options for the meta navigation.
+  params:
+  - name: visuallyHiddenTitle
+    type: string
+    required: false
+    description: Title for a meta item section, which defaults to Support links
+  - name: html
+    type: string
+    required: false
+    description: HTML to add to the meta section of the footer, which will appear below any links specified using meta.items.
+  - name: text
+    type: string
+    required: false
+    description: Text to add to the meta section of the footer, which will appear below any links specified using meta.items. If meta.html is specified, this option is ignored.
+  - name: items
+    type: array
+    required: false
+    description: Array of items for use in the meta section of the footer.
+    params:
+    - name: text
+      type: string
+      required: true
+      description: List item text in the meta section of the footer.
+    - name: href
+      type: string
+      required: true
+      description: List item href attribute in the meta section of the footer.
+    - name: attributes
+      type: object
+      required: false
+      description: HTML attributes (for example data attributes) to add to the anchor in the footer meta section.
+- name: navigation
+  type: array
+  required: false
+  description: Array of items for use in the navigation section of the footer.
+  params:
+  - name: title
+    type: string
+    required: true
+    description: Title for a section
+  - name: columns
+    type: integer
+    required: false
+    description: Amount of columns to display items in navigation section of the footer.
+  - name: items
+    type: array
+    required: false
+    description: Array of items to display in the list in navigation section of the footer.
+    params:
+    - name: text
+      type: string
+      required: true
+      description: List item text in the navigation section of the footer.
+    - name: href
+      type: string
+      required: true
+      description: List item href attribute in the navigation section of the footer. Both `text` and `href` attributes need to be present to create a link.
+    - name: attributes
+      type: object
+      required: false
+      description: HTML attributes (for example data attributes) to add to the anchor in the footer navigation section.
+- name: containerClasses
+  type: string
+  required: false
+  description: Classes that can be added to the inner container, useful if you want to make the footer full width.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the footer component container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the footer component container.
+
+previewLayout: full-width
+accessibilityCriteria: |
+  Text and links in the Footer must:
+  - have a text contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+
+  Links in the Footer must:
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - indicate when they have focus
+  - change in appearance when touched (in the touch-down state)
+  - change in appearance when hovered
+  - have visible text
+
+  Images in the Footer must:
+  - be presentational when linked to from accompanying text (Open Government Licence (OGL) icon).
+  - have a meaningful accessible name if also a linked element (crest icon).
+
+  Landmarks and Roles in the Footer should:
+  - avoid navigation landmarks or roles
+    "The footer element alone is sufficient for such cases; while a nav element can be used in such cases, it is usually unnecessary." - (https://www.w3.org/TR/html52/sections.html#the-nav-element)
+    Note: This decision has been made based on prior experience seeing removal of overuse of `<nav>` elements from www.GOV.UK, which made it confusing for users of assistive technologies to know what were the most important navigation aspects of GOV.UK.
+    Should be challenged if user research indicates this is an issue.
+
+  - have a role of `contentinfo` at the root of the component (<footer>) (https://www.w3.org/TR/wai-aria-1.1/#contentinfo)
+    Note: This decision has been made given that most uses of this role tend to be used directly on a `<footer>` element.
+    Assumption made is that is most predictable for users of assistive technologies.
+    The spec indicates that `contentinfo` is useful for "Examples of information included in this region of the page are copyrights and links to privacy statements.", which may indicate that it might be better placed around the 'meta' section of this component.
+    Should be challenged if user research indicates this is an issue.
+
+    See also: http://www.brucelawson.co.uk/2013/why-does-html-take-rolecontentinfo
+
+examples:
+- name: default
+  data:
+    {}
+
+- name: with meta
+  description: Secondary navigation with meta information relating to the site
+  data:
+    meta:
+      visuallyHiddenTitle: Items
+      items:
+        - href: '#1'
+          text: Item 1
+        - href: '#2'
+          text: Item 2
+        - href: '#3'
+          text: Item 3
+
+- name: with custom meta
+  description: Custom meta section
+  data:
+    meta:
+      text: GOV.UK Prototype Kit v7.0.1
+
+- name: with meta links and meta content
+  description: Secondary navigation links and custom meta text
+  data:
+    meta:
+      items:
+        - href: '#1'
+          text: Bibendum Ornare
+        - href: '#2'
+          text: Nullam
+        - href: '#3'
+          text: Tortor Fringilla
+        - href: '#4'
+          text: Tellus
+        - href: '#5'
+          text: Egestas Nullam
+        - href: '#6'
+          text: Euismod Etiam
+        - href: '#7'
+          text: Fusce Sollicitudin
+        - href: '#8'
+          text:  Ligula Nullam Ultricies
+      html: Built by the <a href="#" class="govuk-footer__link">Department of Magical Law Enforcement</a>
+
+- name: with custom meta
+  description: Custom meta section
+  data:
+    meta:
+      text: GOV.UK Prototype Kit v7.0.1
+
+- name: with navigation
+  data:
+    navigation:
+      - title: Two column list
+        columns: 2
+        items:
+          - href: '#1'
+            text: Navigation item 1
+          - href: '#2'
+            text: Navigation item 2
+          - href: '#3'
+            text: Navigation item 3
+          - href: '#4'
+            text: Navigation item 4
+          - href: '#5'
+            text: Navigation item 5
+          - href: '#6'
+            text: Navigation item 6
+      - title: Single column list
+        items:
+          - href: '#1'
+            text: Navigation item 1
+          - href: '#2'
+            text: Navigation item 2
+          - href: '#3'
+            text: Navigation item 3
+
+- name: GOV.UK
+  description: A full example based on GOV.UK's current footer
+  data:
+    navigation:
+      - title: Services and information
+        columns: 2
+        items:
+          - href: '/browse/benefits'
+            text: Benefits
+          - href: '/browse/births-deaths-marriages'
+            text: Births, deaths, marriages and care
+          - href: '/browse/business'
+            text: Business and self-employed
+          - href: '/browse/childcare-parenting'
+            text: Childcare and parenting
+          - href: '/browse/citizenship'
+            text: Citizenship and living in the UK
+          - href: '/browse/justice'
+            text: Crime, justice and the law
+          - href: '/browse/disabilities'
+            text: Disabled people
+          - href: '/browse/driving'
+            text: Driving and transport
+          - href: '/browse/education'
+            text: Education and learning
+          - href: '/browse/employing-people'
+            text: Employing people
+          - href: '/browse/environment-countryside'
+            text: Environment and countryside
+          - href: '/browse/housing-local-services'
+            text: Housing and local services
+          - href: '/browse/tax'
+            text: Money and tax
+          - href: '/browse/abroad'
+            text: Passports, travel and living abroad
+          - href: '/browse/visas-immigration'
+            text: Visas and immigration
+          - href: '/browse/working'
+            text: Working, jobs and pensions
+      - title: Departments and policy
+        items:
+          - href: '/government/how-government-works'
+            text: How government works
+          - href: '/government/organisations'
+            text: Departments
+          - href: '/world'
+            text: Worldwide
+          - href: '/government/policies'
+            text: Policies
+          - href: '/government/publications'
+            text: Publications
+          - href: '/government/announcements'
+            text: Announcements
+    meta:
+      items:
+        - href: '/help'
+          text: Help
+        - href: '/help/cookies'
+          text: Cookies
+        - href: '/contact'
+          text: Contact
+        - href: '/help/terms-conditions'
+          text: Terms and conditions
+        - href: '/cymraeg'
+          text: Rhestr o Wasanaethau Cymraeg
+      html: Built by the <a class="govuk-footer__link" href="#">Government Digital Service</a>
+
+- name: Three equal columns
+  description: A full example to demonstrate three equal width columns
+  data:
+    navigation:
+      - title: Single column list 1
+        columns: 1
+        items:
+          - href: '#1'
+            text: Navigation item 1
+          - href: '#2'
+            text: Navigation item 2
+          - href: '#3'
+            text: Navigation item 3
+          - href: '#4'
+            text: Navigation item 4
+          - href: '#5'
+            text: Navigation item 5
+          - href: '#6'
+            text: Navigation item 6
+      - title: Single column list 2
+        columns: 1
+        items:
+          - href: '#1'
+            text: Navigation item 1
+          - href: '#2'
+            text: Navigation item 2
+          - href: '#3'
+            text: Navigation item 3
+          - href: '#4'
+            text: Navigation item 4
+          - href: '#5'
+            text: Navigation item 5
+          - href: '#6'
+            text: Navigation item 6
+      - title: Single column list 3
+        columns: 1
+        items:
+          - href: '#1'
+            text: Navigation item 1
+          - href: '#2'
+            text: Navigation item 2
+          - href: '#3'
+            text: Navigation item 3
+          - href: '#4'
+            text: Navigation item 4
+          - href: '#5'
+            text: Navigation item 5
+          - href: '#6'
+            text: Navigation item 6
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: attributes
+  data:
+    attributes:
+      data-test-attribute: value
+      data-test-attribute-2: value-2
+- name: classes
+  data:
+    classes: app-footer--custom-modifier
+- name: with container classes
+  data:
+    containerClasses: app-width-container
+- name: with empty meta
+  data:
+    meta: {}
+- name: with empty meta items
+  data:
+    meta:
+      items: []
+- name: meta html as text
+  data:
+    meta:
+      text: GOV.UK Prototype Kit <strong>v7.0.1</strong>
+- name: with meta html
+  data:
+    meta:
+      html: GOV.UK Prototype Kit <strong>v7.0.1</strong>
+- name: with meta item attributes
+  data:
+    meta:
+      items:
+        - href: '#1'
+          text: meta item 1
+          attributes:
+            data-attribute: my-attribute
+            data-attribute-2: my-attribute-2
+- name: with empty navigation
+  data:
+    navigation: []
+- name: with navigation item attributes
+  data:
+    navigation:
+      -
+        items:
+          - href: '#1'
+            text: Navigation item 1
+            attributes:
+              data-attribute: my-attribute
+              data-attribute-2: my-attribute-2

--- a/src/components/footer/footer.yaml
+++ b/src/components/footer/footer.yaml
@@ -354,3 +354,6 @@ examples:
             attributes:
               data-attribute: my-attribute
               data-attribute-2: my-attribute-2
+- name: welsh language
+  data:
+    language: cy

--- a/src/components/footer/macro.njk
+++ b/src/components/footer/macro.njk
@@ -1,0 +1,3 @@
+{% macro hmrcFooter(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/components/footer/template.njk
+++ b/src/components/footer/template.njk
@@ -1,0 +1,87 @@
+<footer class="govuk-footer {{ params.classes if params.classes }}" role="contentinfo"
+        {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+  <div class="govuk-width-container {{ params.containerClasses if params.containerClasses }}">
+    {% if params.navigation | length %}
+      <div class="govuk-footer__navigation">
+        {% for nav in params.navigation %}
+          <div class="govuk-footer__section">
+            <h2 class="govuk-footer__heading govuk-heading-m">{{ nav.title }}</h2>
+            {% if nav.items | length %}
+              {% set listClasses %}
+                {% if nav.columns %}
+                  govuk-footer__list--columns-{{ nav.columns }}
+                {% endif %}
+              {% endset %}
+              <ul class="govuk-footer__list {{ listClasses | trim }}">
+                {% for item in nav.items %}
+                  {% if item.href and item.text %}
+                    <li class="govuk-footer__list-item">
+                      <a class="govuk-footer__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+                        {{ item.text }}
+                      </a>
+                    </li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </div>
+        {% endfor %}
+      </div>
+      <hr class="govuk-footer__section-break">
+    {% endif %}
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        {% if params.meta %}
+          <h2 class="govuk-visually-hidden">{{ params.meta.visuallyHiddenTitle | default("Support links") }}</h2>
+          {% if params.meta.items | length %}
+            <ul class="govuk-footer__inline-list">
+              {% for item in params.meta.items %}
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+                    {{ item.text }}
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+          {% if params.meta.text or params.meta.html %}
+            <div class="govuk-footer__meta-custom">
+              {{ params.meta.html | safe if params.meta.html else params.meta.text }}
+            </div>
+          {% endif %}
+        {% endif %}
+        {#- The SVG needs `focusable="false"` so that Internet Explorer does not
+        treat it as an interactive element - without this it will be
+        'focusable' when using the keyboard to navigate. #}
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          class="govuk-footer__licence-logo"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 483.2 195.7"
+          height="17"
+          width="41"
+        >
+          <path
+            fill="currentColor"
+            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+          />
+        </svg>
+        <span class="govuk-footer__licence-description">
+          All content is available under the
+          <a
+            class="govuk-footer__link"
+            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+            rel="license"
+          >Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a
+          class="govuk-footer__link govuk-footer__copyright-logo"
+          href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+        >© Crown copyright</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/src/components/footer/template.njk
+++ b/src/components/footer/template.njk
@@ -68,12 +68,12 @@
           />
         </svg>
         <span class="govuk-footer__licence-description">
-          {% if(params.language == 'cy') %}Mae‘r holl gynnwys ar gael o dan y {% else %}All content is available under the {% endif %}
+          {% if(params.language == 'cy') %}Mae‘r holl gynnwys ar gael o dan {% else %}All content is available under the {% endif %}
           <a
             class="govuk-footer__link"
             href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
             rel="license"
-          >          {% if(params.language == 'cy') %}Drwydded Llywodraeth Agored{% else %}Open Government Licence{% endif %}  v3.0</a>, {% if(params.language == 'cy') %}oni nodir yn wahanol{% else %}except where otherwise stated{% endif %}
+          >          {% if(params.language == 'cy') %}y Drwydded Llywodraeth Agored{% else %}Open Government Licence{% endif %}  v3.0</a>, {% if(params.language == 'cy') %}oni nodir yn wahanol{% else %}except where otherwise stated{% endif %}
 
         </span>
       </div>
@@ -81,7 +81,7 @@
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >© Crown copyright</a>
+        >© {% if(params.language == 'cy') %}Hawlfraint y Goron{% else %}Crown copyright{% endif %}</a>
       </div>
     </div>
   </div>

--- a/src/components/footer/template.njk
+++ b/src/components/footer/template.njk
@@ -32,7 +32,8 @@
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         {% if params.meta %}
-          <h2 class="govuk-visually-hidden">{{ params.meta.visuallyHiddenTitle | default("Support links") }}</h2>
+          {% set supportLinksDefaultText %}{% if params.language == "cy" %}Cysylltiadau cymorth{% else %}Support links{% endif %}{% endset %}
+          <h2 class="govuk-visually-hidden">{{ params.meta.visuallyHiddenTitle | default(supportLinksDefaultText) }}</h2>
           {% if params.meta.items | length %}
             <ul class="govuk-footer__inline-list">
               {% for item in params.meta.items %}

--- a/src/components/footer/template.njk
+++ b/src/components/footer/template.njk
@@ -68,12 +68,13 @@
           />
         </svg>
         <span class="govuk-footer__licence-description">
-          All content is available under the
+          {% if(params.language == 'cy') %}Mae‘r holl gynnwys ar gael o dan y {% else %}All content is available under the {% endif %}
           <a
             class="govuk-footer__link"
             href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
             rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
+          >          {% if(params.language == 'cy') %}Drwydded Llywodraeth Agored{% else %}Open Government Licence{% endif %}  v3.0</a>, {% if(params.language == 'cy') %}oni nodir yn wahanol{% else %}except where otherwise stated{% endif %}
+
         </span>
       </div>
       <div class="govuk-footer__meta-item">

--- a/src/components/footer/template.test.js
+++ b/src/components/footer/template.test.js
@@ -1,0 +1,200 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-env jest */
+
+const axe = require('../../../../lib/axe-helper')
+
+const { render, getExamples } = require('../../../../lib/jest-helpers')
+
+const examples = getExamples('footer')
+
+describe('footer', () => {
+  it('default example passes accessibility tests', async () => {
+    const $ = render('footer', examples.default)
+
+    const results = await axe($.html())
+    expect(results).toHaveNoViolations()
+  })
+
+  it('entire component must have a role of `contentinfo`', () => {
+    const $ = render('footer', examples.default)
+
+    const $component = $('.govuk-footer')
+    expect($component.attr('role')).toEqual('contentinfo')
+  })
+
+  it('renders attributes correctly', () => {
+    const $ = render('footer', examples.attributes)
+
+    const $component = $('.govuk-footer')
+    expect($component.attr('data-test-attribute')).toEqual('value')
+    expect($component.attr('data-test-attribute-2')).toEqual('value-2')
+  })
+
+  it('renders classes', () => {
+    const $ = render('footer', examples.classes)
+
+    const $component = $('.govuk-footer')
+    expect($component.hasClass('app-footer--custom-modifier')).toBeTruthy()
+  })
+
+  it('renders custom container classes', () => {
+    const $ = render('footer', examples['with container classes'])
+
+    const $component = $('.govuk-footer')
+    const $container = $component.find('.govuk-width-container')
+
+    expect($container.hasClass('app-width-container')).toBeTruthy()
+  })
+
+  describe('meta', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('footer', examples['with meta'])
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('renders heading', () => {
+      const $ = render('footer', examples['with meta'])
+
+      const $component = $('.govuk-footer')
+      const $heading = $component.find('h2.govuk-visually-hidden')
+      expect($heading.text()).toEqual('Items')
+    })
+
+    it('renders default heading when none supplied', () => {
+      const $ = render('footer', examples['with empty meta'])
+
+      const $component = $('.govuk-footer')
+      const $heading = $component.find('h2.govuk-visually-hidden')
+      expect($heading.text()).toEqual('Support links')
+    })
+
+    it('doesn\'t render footer link list when no items are provided', () => {
+      const $ = render('footer', examples['with empty meta items'])
+
+      const $component = $('.govuk-footer')
+      expect($component.find('.govuk-footer__inline-list').length).toEqual(0)
+    })
+
+    it('renders links', () => {
+      const $ = render('footer', examples['with meta'])
+
+      const $component = $('.govuk-footer')
+      const $list = $component.find('ul.govuk-footer__inline-list')
+      const $items = $list.find('li.govuk-footer__inline-list-item')
+      const $firstItem = $items.find('a.govuk-footer__link:first-child')
+      expect($items.length).toEqual(3)
+      expect($firstItem.attr('href')).toEqual('#1')
+      expect($firstItem.text()).toContain('Item 1')
+    })
+
+    it('renders custom meta text', () => {
+      const $ = render('footer', examples['with custom meta'])
+
+      const $component = $('.govuk-footer')
+      const $custom = $component.find('.govuk-footer__meta-custom')
+      expect($custom.text()).toContain('GOV.UK Prototype Kit v7.0.1')
+    })
+
+    it('renders custom meta html as text', () => {
+      const $ = render('footer', examples['meta html as text'])
+
+      const $component = $('.govuk-footer')
+      const $custom = $component.find('.govuk-footer__meta-custom')
+      expect($custom.text()).toContain('GOV.UK Prototype Kit <strong>v7.0.1</strong>')
+    })
+
+    it('renders custom meta html', () => {
+      const $ = render('footer', examples['with meta html'])
+
+      const $component = $('.govuk-footer')
+      const $custom = $component.find('.govuk-footer__meta-custom')
+      expect($custom.text()).toContain('GOV.UK Prototype Kit v7.0.1')
+    })
+
+    it('renders attributes on meta links', () => {
+      const $ = render('footer', examples['with meta item attributes'])
+
+      const $metaLink = $('.govuk-footer__meta .govuk-footer__link')
+      expect($metaLink.attr('data-attribute')).toEqual('my-attribute')
+      expect($metaLink.attr('data-attribute-2')).toEqual('my-attribute-2')
+    })
+  })
+
+  describe('navigation', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('footer', examples['with navigation'])
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('no items displayed when no item array is provided', () => {
+      const $ = render('footer', examples['with empty navigation'])
+
+      const $component = $('.govuk-footer')
+      expect($component.find('.govuk-footer__navigation').length).toEqual(0)
+    })
+
+    it('renders headings', () => {
+      const $ = render('footer', examples['with navigation'])
+
+      const $component = $('.govuk-footer')
+      const $firstSection = $component.find('.govuk-footer__section:first-child')
+      const $lastSection = $component.find('.govuk-footer__section:last-child')
+      const $firstHeading = $firstSection.find('h2.govuk-footer__heading')
+      const $lastHeading = $lastSection.find('h2.govuk-footer__heading')
+      expect($firstHeading.text()).toEqual('Two column list')
+      expect($lastHeading.text()).toEqual('Single column list')
+    })
+
+    it('renders lists of links', () => {
+      const $ = render('footer', examples['with navigation'])
+
+      const $component = $('.govuk-footer')
+      const $list = $component.find('ul.govuk-footer__list')
+      const $items = $list.find('li.govuk-footer__list-item')
+      const $firstItem = $items.find('a.govuk-footer__link:first-child')
+      expect($items.length).toEqual(9)
+      expect($firstItem.attr('href')).toEqual('#1')
+      expect($firstItem.text()).toContain('Navigation item 1')
+    })
+
+    it('renders attributes on links', () => {
+      const $ = render('footer', examples['with navigation item attributes'])
+
+      const $navigationLink = $('.govuk-footer__list .govuk-footer__link')
+      expect($navigationLink.attr('data-attribute')).toEqual('my-attribute')
+      expect($navigationLink.attr('data-attribute-2')).toEqual('my-attribute-2')
+    })
+
+    it('renders lists in columns', () => {
+      const $ = render('footer', examples['with navigation'])
+
+      const $component = $('.govuk-footer')
+      const $list = $component.find('ul.govuk-footer__list')
+      expect($list.hasClass('govuk-footer__list--columns-2')).toBeTruthy()
+    })
+  })
+
+  describe('section break', () => {
+    it('renders when there is a navigation', () => {
+      const $ = render('footer', examples['with navigation'])
+
+      const $component = $('.govuk-footer')
+      const $sectionBreak = $component.find('hr.govuk-footer__section-break')
+      expect($sectionBreak.length).toBeTruthy()
+    })
+
+    it('renders nothing when there is only meta', () => {
+      const $ = render('footer', examples['with meta'])
+
+      const $component = $('.govuk-footer')
+      const $sectionBreak = $component.find('hr.govuk-footer__section-break')
+      expect($sectionBreak.length).toBeFalsy()
+    })
+  })
+})

--- a/src/components/footer/template.test.js
+++ b/src/components/footer/template.test.js
@@ -209,6 +209,8 @@ describe('footer', () => {
       const $component = $('.govuk-footer')
       const $licenceDescription = $component.find('.govuk-footer__licence-description')
       expect(normaliseText($licenceDescription.text())).toBe('All content is available under the Open Government Licence v3.0, except where otherwise stated')
+      expect(normaliseText($licenceDescription.find('a').text())).toBe('Open Government Licence v3.0')
+      expect(normaliseText($component.find('.govuk-footer__link.govuk-footer__copyright-logo').text())).toBe('© Crown copyright')
     })
 
     it('renders in Welsh', () => {
@@ -217,6 +219,8 @@ describe('footer', () => {
       const $component = $('.govuk-footer')
       const $licenceDescription = $component.find('.govuk-footer__licence-description')
       expect(normaliseText($licenceDescription.text())).toBe('Mae‘r holl gynnwys ar gael o dan y Drwydded Llywodraeth Agored v3.0, oni nodir yn wahanol')
+      expect(normaliseText($licenceDescription.find('a').text())).toBe('y Drwydded Llywodraeth Agored v3.0')
+      expect(normaliseText($component.find('.govuk-footer__link.govuk-footer__copyright-logo').text())).toBe('© Hawlfraint y Goron')
     })
   })
 })

--- a/src/components/footer/template.test.js
+++ b/src/components/footer/template.test.js
@@ -76,6 +76,14 @@ describe('footer', () => {
       expect($heading.text()).toEqual('Support links')
     })
 
+    it('renders default heading in Welsh when none supplied', () => {
+      const $ = render('footer', examples['with empty meta in Welsh'])
+
+      const $component = $('.govuk-footer')
+      const $heading = $component.find('h2.govuk-visually-hidden')
+      expect($heading.text()).toEqual('Cysylltiadau cymorth')
+    })
+
     it('doesn\'t render footer link list when no items are provided', () => {
       const $ = render('footer', examples['with empty meta items'])
 

--- a/src/components/footer/template.test.js
+++ b/src/components/footer/template.test.js
@@ -3,13 +3,17 @@
  */
 /* eslint-env jest */
 
-const axe = require('../../../../lib/axe-helper')
+const axe = require('../../../lib/axe-helper')
 
-const { render, getExamples } = require('../../../../lib/jest-helpers')
+const { render, getExamples } = require('../../../lib/jest-helpers')
 
 const examples = getExamples('footer')
 
 describe('footer', () => {
+  function normaliseText (text) {
+    return (text || '').trim().replace(/\s+/g, ' ')
+  }
+
   it('default example passes accessibility tests', async () => {
     const $ = render('footer', examples.default)
 
@@ -195,6 +199,24 @@ describe('footer', () => {
       const $component = $('.govuk-footer')
       const $sectionBreak = $component.find('hr.govuk-footer__section-break')
       expect($sectionBreak.length).toBeFalsy()
+    })
+  })
+
+  describe('Copyright notice', () => {
+    it('renders in English', () => {
+      const $ = render('footer', examples['with empty navigation'])
+
+      const $component = $('.govuk-footer')
+      const $licenceDescription = $component.find('.govuk-footer__licence-description')
+      expect(normaliseText($licenceDescription.text())).toBe('All content is available under the Open Government Licence v3.0, except where otherwise stated')
+    })
+
+    it('renders in Welsh', () => {
+      const $ = render('footer', examples['welsh language'])
+
+      const $component = $('.govuk-footer')
+      const $licenceDescription = $component.find('.govuk-footer__licence-description')
+      expect(normaliseText($licenceDescription.text())).toBe('Mae‘r holl gynnwys ar gael o dan y Drwydded Llywodraeth Agored v3.0, oni nodir yn wahanol')
     })
   })
 })


### PR DESCRIPTION
We've had a number of requests for Welsh Language Footers, GDS aren't providing this so it's time to treat it seems appropriate to treat the Welsh Footer as an HMRC requirement.  This PR includes a clone of the current GOVUK footer with Welsh text added.

Welsh translations were taken from https://www.tax.service.gov.uk/pay which I'm told is accurate.

This follows the approach we've taken for the `govukHeader` which needed customising for HMRC's usage leading to the creation of `hmrcHeader`.