### PR TITLE
Simplify timeout-dialog so polyfills can be removed, reducing overall bundle size

### DIFF
--- a/src/components/timeout-dialog/dialog.js
+++ b/src/components/timeout-dialog/dialog.js
@@ -62,7 +62,9 @@ function displayDialog($elementToDisplay) {
     }
   };
   const closeAndInform = () => {
-    closeCallbacks.forEach((fn) => { fn(); });
+    for (let i = 0; i < closeCallbacks.length; i += 1) {
+      closeCallbacks[i]();
+    }
     close();
   };
   const setupKeydownHandler = () => {

--- a/src/components/timeout-dialog/timeout-dialog.test.js
+++ b/src/components/timeout-dialog/timeout-dialog.test.js
@@ -80,7 +80,7 @@ describe('/components/timeout-dialog', () => {
       currentDateTime: 1554196031049, // the time these tests were written
       // - this can change but it's best not to write randomness into tests
     };
-    mock.spyOn(Date, 'now').mockImplementation(() => testScope.currentDateTime);
+    mock.spyOn(Date.prototype, 'getTime').mockImplementation(() => testScope.currentDateTime);
     mock.spyOn(utils, 'ajaxGet').mockImplementation(() => {
     });
     mock.spyOn(redirectHelper, 'redirectToUrl').mockImplementation(() => {


### PR DESCRIPTION
The total js bundle size for our service is 40kb, removing the polyfills in `timeout-dialog.js` reduces our bundle to 30kb, meaning 25% of the js we were shipping was just polyfills for the timeout-dialog component. So I've simplifed the code to remove functions (such as `Object.assign()`) that require polyfilling.