### PR TITLE
Update package-lock.json to have current version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "1.28.0",
+  "version": "1.30.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This getting out of sync isn't much of a problem because when a release artifact is built it will run npm install which bumps this number so any released stuff should have the correct version number 👍 