### PR TITLE
Allowing multiple Character Count components on one page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.32.0] - 2021-04-29
+
+## Fixed
+
+- Allowing the initialization of multiple character counts on a single page when using `initAll`
+
 ## 1.31.0 - 2021-04-27
 
 ### Fixed

--- a/src/all.js
+++ b/src/all.js
@@ -2,6 +2,7 @@ import AccountMenu from './components/account-menu/account-menu';
 import TimeoutDialog from './components/timeout-dialog/timeout-dialog';
 import UserResearchBanner from './components/user-research-banner/user-research-banner';
 import CharacterCount from './components/character-count/character-count';
+import { nodeListForEach } from './common';
 
 function initAll() {
   const $AccountMenuSelector = '[data-module="hmrc-account-menu"]';
@@ -19,10 +20,10 @@ function initAll() {
     new UserResearchBanner($UserResearchBanner).init();
   }
 
-  const $CharacterCount = document.querySelector('[data-module="hmrc-character-count"]');
-  if ($CharacterCount) {
+  const $CharacterCounts = document.querySelectorAll('[data-module="hmrc-character-count"]');
+  nodeListForEach($CharacterCounts, ($CharacterCount) => {
     new CharacterCount($CharacterCount).init();
-  }
+  });
 }
 
 export default {
@@ -31,4 +32,5 @@ export default {
   TimeoutDialog,
   UserResearchBanner,
   CharacterCount,
+
 };

--- a/src/all.test.js
+++ b/src/all.test.js
@@ -1,0 +1,91 @@
+/* eslint-env jest */
+/* global spyOn */
+import HMRCFrontend from './all';
+import * as characterCountModule from './components/character-count/character-count';
+
+describe('Init All', () => {
+  let testScope;
+  beforeEach(() => {
+    testScope = {
+      elemsToWipe: [],
+    };
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+    testScope.elemsToWipe.forEach((elem, key) => {
+      const parent = elem.parentNode;
+      if (parent) {
+        parent.removeChild(elem);
+      } else {
+        throw new Error(`failed to remove child ${key}`);
+      }
+    });
+    testScope.elemsToWipe = [];
+  });
+  describe('Character Count', () => {
+    function createCharCountModule() {
+      const elem = document.createElement('div');
+      testScope.elemsToWipe.push(elem);
+      elem.setAttribute('data-module', 'hmrc-character-count');
+      document.querySelector('body').appendChild(elem);
+      return elem;
+    }
+
+    it('should initialise one module', () => {
+      const initFn = jest.fn();
+      const elem = createCharCountModule();
+      spyOn(characterCountModule, 'default').and.returnValue({ init: initFn });
+      expect(characterCountModule.default).not.toHaveBeenCalled();
+      HMRCFrontend.initAll();
+      expect(characterCountModule.default).toHaveBeenCalledWith(elem);
+      expect(initFn).toHaveBeenCalled();
+    });
+
+    it('should not initialise when there are no modules', () => {
+      const initFn = jest.fn();
+      spyOn(characterCountModule, 'default').and.returnValue({ init: initFn });
+      HMRCFrontend.initAll();
+      expect(characterCountModule.default).not.toHaveBeenCalled();
+      expect(initFn).not.toHaveBeenCalled();
+    });
+
+    it('should initialise four modules', () => {
+      const elemA = createCharCountModule();
+      const elemB = createCharCountModule();
+      const elemC = createCharCountModule();
+      const elemD = createCharCountModule();
+      const initFnA = jest.fn();
+      const initFnB = jest.fn();
+      const initFnC = jest.fn();
+      const initFnD = jest.fn();
+      const unusedInitFn = jest.fn();
+      spyOn(characterCountModule, 'default').and.callFake((elem) => {
+        let init = unusedInitFn;
+        if (elem === elemA) {
+          init = initFnA;
+        }
+        if (elem === elemB) {
+          init = initFnB;
+        }
+        if (elem === elemC) {
+          init = initFnC;
+        }
+        if (elem === elemD) {
+          init = initFnD;
+        }
+        return { init };
+      });
+      expect(characterCountModule.default).not.toHaveBeenCalled();
+      HMRCFrontend.initAll();
+      expect(characterCountModule.default).toHaveBeenCalledWith(elemA);
+      expect(characterCountModule.default).toHaveBeenCalledWith(elemB);
+      expect(characterCountModule.default).toHaveBeenCalledWith(elemC);
+      expect(characterCountModule.default).toHaveBeenCalledWith(elemD);
+      expect(initFnA).toHaveBeenCalled();
+      expect(initFnB).toHaveBeenCalled();
+      expect(initFnC).toHaveBeenCalled();
+      expect(initFnD).toHaveBeenCalled();
+      expect(unusedInitFn).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
The problem report page currently has a broken character count (https://www.tax.service.gov.uk/contact/problem_reports_nonjs), the first one works and the second one doesn't. That's because `init-all.js` uses `querySelector` instad of `querySelectorAll` (https://github.com/hmrc/hmrc-frontend/blob/master/src/all.js#L22).

This can be reproduced in the prototype kit using this template:

```

{% extends "layout.html" %} {% block pageTitle %}
GOV.UK Prototype Kit

{% endblock %}
{% block content %} {%- from "hmrc/components/character-count/macro.njk" import hmrcCharacterCount -%}


{{ hmrcCharacterCount({
name: "abc",
id: "abc",
maxlength: 200,
label: { text: "This one will work", classes: "govuk-label--l" }
}) }}
{{ hmrcCharacterCount({
name: "def",
id: "def",
maxlength: 200,
label: { text: "This one will be broken", classes: "govuk-label--l" }
}) }}
{% endblock %}
```

Multiple character counts should be supported on one page.  This PR resolves the issue for anyone using `initAll`.