### PR TITLE
Netlify deploy previews for pull requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ __tests__/hmrc-frontend
 backstop_data/bitmaps_test/*
 backstop_data/html_report/*
 
+netlify

--- a/app/app.js
+++ b/app/app.js
@@ -32,6 +32,13 @@ module.exports = (options) => {
     ...nunjucksOptions, // merge any additional options and overwrite defaults above.
   });
 
+  env.addFilter(
+    'componentExamples',
+    (component) => fileHelper.getComponentData(component).examples.map(
+      (example) => example.name.replace(/ /g, '-'),
+    ),
+  );
+
   // Set view engine
   app.set('view engine', 'njk');
 

--- a/app/views/layouts/index.njk
+++ b/app/views/layouts/index.njk
@@ -9,11 +9,18 @@
 
     <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-m">Components</h2>
-      <ul class="govuk-list">
+      <dl class="govuk-list">
         {% for componentName in componentsDirectory | sort %}
-          <li><a href="/components/{{ componentName }}/preview" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
+          <dt><a href="/components/{{ componentName }}/preview" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></dt>
+          <dd>
+            <ul class="govuk-list">
+              {% for exampleName in componentName | componentExamples %}
+                <li><a href="/components/{{ componentName }}/{{ exampleName }}/preview" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }} example</a></li>
+              {% endfor %}
+            </ul>
+          </dd>
         {% endfor %}
-      </ul>
+      </dl>
     </div>
   </div>
 {% endblock %}

--- a/netlify.js
+++ b/netlify.js
@@ -1,0 +1,45 @@
+/* eslint-env node */
+
+const { spawn, execSync } = require('child_process');
+
+// Create a static version of the site which can be hosted in a netlify deploy preview
+
+// 1. build static assets
+execSync('gulp build:dist', { stdio: 'inherit' });
+
+const port = process.env.PORT || 3000;
+
+// 2. start server
+const server = require('./app/app.js')().listen(port, () => {
+  process.stdout.write(`Server started at http://localhost:${port}\n`);
+});
+
+// 3. build a static mirror of site by crawling server
+const wget = spawn('wget', [
+  '--mirror', // because we want to crawl the site recursively
+  '--page-requisites', // because we want things like css, javascript, fonts, and images
+  '--adjust-extension', // because we want /preview links to become /preview.html links
+  '--convert-links', // because we want the links to work in the static version
+  '--directory-prefix', './netlify', // because we want to output to ./netlify
+  '--no-host-directories', // because we want './netlify/index.html' not './netlify/localhost:3000/index.html'
+  '--execute', 'robots=off', // because the existing robots.txt disallows wget so we only get index.html
+  '--accept-regex', `localhost:${port}`, // because we don't want to try to visit any external links
+  '--reject-regex', '\\?', // because we don't want to download links that have query strings
+  '--timeout', '5', // seconds, because we don't want this to hang forever and eat up build minutes
+  `http://localhost:${port}`,
+], { stdio: 'inherit' });
+
+// 4. stop server
+wget.on('exit', () => {
+  process.stdout.write(`Finished crawling site, stopping server http://localhost:${port}...\n`);
+
+  server.close(() => {
+    process.stdout.write('Server closed gracefully\n');
+    process.exit(0);
+  });
+
+  setTimeout(() => {
+    process.stdout.write('Server failed to close gracefully, exiting\n');
+    process.exit(0);
+  }, 6000).unref();
+});

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+publish = "netlify/"
+command = "node netlify.js"


### PR DESCRIPTION
I needed to spin up an example of a change so that I could ask for help retesting the change with JAWS which I don't currently have access to.

I didn't want to have to manually create or update something in a prototype so I forked hmrc/hmrc-frontend and setup Netlify on my version so I can raise PRs there and get a deployment preview automatically spun up for me to share.

Netlify is a static site hosting platform that is also currently in use within GDS (also for it's deployment preview workflow, for example alphagov/govuk-design-system https://github.com/alphagov/govuk-design-system/pull/1632#issuecomment-826740080)

Because it only hosts static sites, I created a script to crawl the running dev server with wget and create a static mirror of the site. And then following on from that, because we currently only link to the default examples, I introduced nested links to all the examples from the listing page so that the static mirrors would have all the examples included rather than just the default.

I'm creating this draft PR now that I've done that to see if there's any interest in bringing these changes into the repository and having deploy previews run automatically on all PRs.

For an example from my repo, see https://github.com/oscarduignan/hmrc-frontend/pull/2 - and I guess even if we don't setup the deploy previews on this repository, there might be some value in merging the changes because then people could create their own forks and enable netlify on the forks themselves if they want to play around with changes to the components.