### PR TITLE
Revert Number.isNaN to isNaN

### DIFF
--- a/src/components/timeout-dialog/validate-input.js
+++ b/src/components/timeout-dialog/validate-input.js
@@ -3,7 +3,8 @@ function ValidateInput() {
 
 ValidateInput.int = (stringToValidate) => {
   const parsedInt = parseInt(stringToValidate, 10);
-  return Number.isNaN(parsedInt) ? undefined : parsedInt;
+  // eslint-disable-next-line no-restricted-globals
+  return typeof parsedInt === 'number' && isNaN(parsedInt) ? undefined : parsedInt;
 };
 
 ValidateInput.string = (stringToValidate) => stringToValidate && ((`${stringToValidate}`) || undefined);


### PR DESCRIPTION
Fixes #142 

I have reverted to use global `isNaN` with a type check before - reasoning explained in the issue. This then caused an errors in eslint. However, to save having to add lots of polyfiller for this one method i silenced eslint.

I have tested in IE11 with BrowserStack in the demo project and it works fine (it did not before making this change)