### PR TITLE
Adding novalidate as it should be a default on our forms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.35.1] - 2021-05-19
+
+## Changed
+
+- Added novalidate to Add To A List in order to match the standard for forms
+
 ## [1.35.0] - 2021-05-19
 
 ## Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/add-to-a-list/template.njk
+++ b/src/components/add-to-a-list/template.njk
@@ -63,7 +63,7 @@
     {# end loop #}
   </dl>
 </div>
-<form method="post" action="{{ params.formAction }}">
+<form method="post" novalidate action="{{ params.formAction }}">
   {{ govukRadios({
     classes: "govuk-radios--inline",
     idPrefix: "add-another",


### PR DESCRIPTION
While updating the twirl version of this we realised it didn't have a `novalidate` which we include as standard (as per https://design-system.service.gov.uk/patterns/validation/#turn-off-html5-validation).  This PR adds it to `hmrc-frontend` so that there's consistency of behaviour between prototype kits and twirl as well as allowing us to test using the output of `hmrc-frontend`.