### PR TITLE
PLATUI-1212: propose two changes for add-to-a-list

### DIFF
--- a/docs/adr/0002-extract-list-with-actions-from-add-to-a-list.md
+++ b/docs/adr/0002-extract-list-with-actions-from-add-to-a-list.md
@@ -1,0 +1,61 @@
+# Extract list-with-actions component from add-to-a-list pattern
+
+* Status: accepted
+* Deciders: platui, design resources, dias
+* Raised: 2021-06-22
+* Decided: 2021-07-01
+* Components: add-to-a-list, list-with-actions
+
+Technical Story: PLATUI-1212
+
+## Context and Problem Statement
+
+Feedback from service teams that sometimes they need to do things like enforce business rules around the ability to add 
+new items when using the add-to-a-list pattern; or to vary the actions for items where currently you are required to 
+have both a "change" and a "remove" link; and to be able to add more content for the user, for example after the heading.
+
+## Considered Options
+
+* Extract a list-with-actions component from the add-to-a-list pattern
+* Change the API of add-to-a-list to be more flexible based on feedback
+
+## Decision Outcome
+
+Consensus is to extract a list-with-actions component from the add-to-a-list pattern, implemented flexibly so that it
+can be potentially used as part of other patterns. We discussed that the original intention of the add-to-a-list pattern
+was that it would be more of a suggested composition of components for a common use case (a pattern in the GDS sense)
+and not itself be a single component. In the future we may look to deprecate the add-to-a-list component
+implementations.
+
+## Pros and Cons of the Options
+
+### Option 1: extract a list-with-actions component from the add-to-a-list pattern
+
+The add-to-a-list pattern is composed of a title, a list with actions, and a form with a radio button group. Currently
+the list with actions part of the pattern is implemented inline. This option would extract that inner implementation
+into a component of its own that add-to-a-list would then use internally.
+
+* Good, because it makes it possible to compose a variation of this pattern without having to reimplement the parts not 
+  being changed
+* Good, because we give teams the flexibility to experiment and test changes to this pattern which we can benefit from
+* Good, because the list-with-actions component could be useful in other patterns
+* Good, because we don't have to change the API for the add-to-a-list component so it's simpler to implement and won't 
+  break any existing usages (though not sure there are many)
+* Good, because we have more control to change this part of the pattern in the future
+* Bad, because we have less control to change the overall pattern in the future if people compose it themselves
+
+### Option 2: change the API of add-to-a-list to be more flexible
+
+Context and problem statement has some examples of changes based on feedback that we've received. To support the changes
+we'd have to make some values optional and add some new options.
+
+* Good, because we have more control to change the overall pattern in the future
+* Good, because it would be less work for teams to implement these variations (if we have covered their use case)
+* Bad, because we haven't got evidence supporting some of these variations of the pattern yet
+* Bad, because if their use case wasn't supported then teams might have to reimplement the component if they needed a 
+  new variation on a tight deadline
+
+## Links
+
+* [Discussion thread for add-to-a-list pattern](https://github.com/hmrc/design-patterns/issues/31)
+* [Documentation for add-to-a-list pattern](https://design.tax.service.gov.uk/hmrc-design-patterns/add-to-a-list/)

--- a/docs/adr/0003-change-api-of-add-to-a-list-form.md
+++ b/docs/adr/0003-change-api-of-add-to-a-list-form.md
@@ -1,0 +1,86 @@
+# Change API of add-to-a-list form
+
+* Status: accepted
+* Deciders: platui, design resources
+* Raised: 2021-06-22
+* Decided: 2021-07-01
+* Components: add-to-a-list
+
+Technical Story: PLATUI-1212
+
+## Context and Problem Statement
+
+The radio buttons in add-to-a-list are using the translated strings `messages.yes` and `messages.no` for their value.
+This means when the form is submitted the handler services must understand and respond correctly to both "Yes/No" and 
+"Iawn/Na". For teams this may be easy to forget and miss from test coverage. Maintainers of the implementation may also 
+not realise that changing the translation could break handling of the submitted form for services using this pattern.
+
+Code example from nunjucks implementation:
+```
+  ...
+  {{ govukRadios({
+    classes: "govuk-radios--inline",
+    idPrefix: "add-another",
+    name: "add-another",
+    fieldset: {
+      legend: {
+        text:  messages.addAnother.prefix + " " + params.itemType.singular | default(messages.itemTypeDefault.singular) + messages.addAnother.suffix + "?",
+        isPageHeading: false,
+        classes: "govuk-fieldset__legend govuk-fieldset__legend--m"
+      }
+    },
+    hint: {
+      text: params.hintText
+    },
+    items: [
+      { text: messages.yes, value: messages.yes },
+      { text: messages.no, value: messages.no }
+    ] }) }}
+    ...
+```
+
+Taken from: https://github.com/hmrc/hmrc-frontend/blob/ed7d1b99009f3e032ec6553bdc6d518b4d1a66f8/src/components/add-to-a-list/template.njk#L82-L83
+
+## Decision Drivers
+
+* we want to have a stable predictable interface for implementers to work to
+* reduce chance that the consequences of changes can be missed
+
+## Considered Options
+
+* Option 1: do nothing
+* Option 2: change to "true" and "false"
+* Option 3: change to "Yes" and "No" (capitalized)
+
+## Decision Outcome
+
+Consensus was to go with option 2 or 3, that this would reduce the work for service teams to use this pattern. There 
+wasn't much preference over what the actual values ended up being, and this decision is less important given the choice
+made at the same time to extract a list-with-actions component which will allow teams to compose the pattern themselves. 
+So we can defer a final choice until the ticket for this change is implemented.
+
+## Pros and Cons of the Options
+
+### Option 1
+
+* Good, we're not breaking any existing usages
+* Bad, we're leaving teams exposed to risk that we could avoid, which might undermine teams confidence in the tools
+
+### Option 2
+
+* Good, because it is based on feedback from a user of this pattern
+* Good, because it's easy to map to a boolean with scala forms (no possibility for mistakes comparing special strings)
+* Bad, because if we wanted to ever introduce another option it would complicate mapping (for example "yes/no/later")
+* Bad, because it will require existing form handlers to be updated
+
+### Option 3
+
+* Good, because it might make it easier to add extra optional choices later (yes/no/later)
+* Good, because it's (almost) not a breaking change (wouldn't break so long as a service has implemented their handler 
+  to allow "Yes/No" regardless of users language preference)
+* Bad, because it's possibly less convenient to map into a scala form than a boolean
+
+## Links
+
+* [Discussion thread for add-to-a-list pattern](https://github.com/hmrc/design-patterns/issues/31)
+* [Documentation for add-to-a-list pattern](https://design.tax.service.gov.uk/hmrc-design-patterns/add-to-a-list/)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -3,8 +3,12 @@
 <!-- adrlog -->
 
 * [ADR-0001](0001-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records (MADRs)
+* [ADR-0002](0002-extract-list-with-actions-from-add-to-a-list.md) - Extract list-with-actions component from add-to-a-list pattern
+* [ADR-0003](0003-change-api-of-add-to-a-list-form.md) - Change API of add-to-a-list form
 
 <!-- adrlogstop -->
+
+
 
 
 


### PR DESCRIPTION
- extract list-with-actions component from add-to-a-list component
- change api of add-to-a-list so it uses fixed form values for radios

meeting to make a decision for both still to be arranged

https://github.com/hmrc/design-patterns/issues/31