### PR TITLE
PLATUI-1188: add links to examples under components on the listing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.1.1] - 2021-08-05
+
+### Changed
+
+- Added links to examples under components on the listing page when running the local dev server
+
 ## [2.1.0] - 2021-08-04
 
 ### Changed

--- a/app/app.js
+++ b/app/app.js
@@ -32,6 +32,14 @@ module.exports = (options) => {
     ...nunjucksOptions, // merge any additional options and overwrite defaults above.
   });
 
+  // Get the list of examples for a component from within a template
+  env.addFilter(
+    'componentExamples',
+    (component) => fileHelper.getComponentData(component).examples.map(
+      (example) => example.name.replace(/ /g, '-'),
+    ),
+  );
+
   // Set view engine
   app.set('view engine', 'njk');
 
@@ -75,15 +83,10 @@ module.exports = (options) => {
   });
 
   // Component 'README' page
-  app.get('/components/:component', (req, res, next) => {
-    // make variables available to nunjucks template
-    res.locals.componentPath = req.params.component;
-    res.render('component', (error, html) => {
-      if (error) {
-        next(error);
-      } else {
-        res.send(html);
-      }
+  app.get('/components/:component([a-zA-Z-]+)', (req, res) => {
+    res.render('component', {
+      hmrcFrontendVersion: pkg.version,
+      componentReadme: fileHelper.getComponentReadme(req.params.component),
     });
   });
 

--- a/app/views/layouts/component.njk
+++ b/app/views/layouts/component.njk
@@ -1,0 +1,5 @@
+{% extends "layout.njk" %}
+
+{% block content %}
+{{ componentReadme|safe }}
+{% endblock %}

--- a/app/views/layouts/index.njk
+++ b/app/views/layouts/index.njk
@@ -6,14 +6,18 @@
   </h1>
 
   <div class="govuk-grid-row">
-
     <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-m">Components</h2>
-      <ul class="govuk-list">
-        {% for componentName in componentsDirectory | sort %}
-          <li><a href="/components/{{ componentName }}/preview" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
-        {% endfor %}
-      </ul>
+      <p class="govuk-body">Follow the links under sub headings below to view examples of the components.</p>
+      {% for componentName in componentsDirectory | sort %}
+        <h3 class="govuk-heading-s">{{ componentName | replace("-", " ") | capitalize }}</h3>
+        <p class="govuk-body"><a href="/components/{{ componentName }}">View the readme</a>, or browse the examples:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          {% for exampleName in componentName | componentExamples %}
+            <li><a href="/components/{{ componentName }}/{{ exampleName }}/preview" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }} example</a></li>
+          {% endfor %}
+        </ul>
+      {% endfor %}
     </div>
   </div>
 {% endblock %}

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
+const Remarkable = require('remarkable');
 
 const configPaths = require('../config/paths.json');
 
@@ -29,3 +30,22 @@ const getComponentData = (componentName) => {
 };
 
 exports.getComponentData = getComponentData;
+
+const md = new Remarkable();
+
+const govukify = (html) => html
+  .replace(/<p>/g, '<p class="govuk-body">')
+  .replace(/<h1/g, '<h1 class="govuk-heading-l"')
+  .replace(/<h2/g, '<h2 class="govuk-heading-m"')
+  .replace(/<h3/g, '<h3 class="govuk-heading-s"')
+  .replace(/<ul/g, '<ul class="govuk-list govuk-list--bullet govuk-list--spaced"')
+  .replace(/<a /g, '<a class="govuk-link" ');
+
+const getComponentReadme = (componentPath) => {
+  const readme = path.join(configPaths.components, componentPath, 'README.md');
+  const markdown = readFileContents(readme);
+  const html = md.render(markdown);
+  return govukify(html);
+};
+
+exports.getComponentReadme = getComponentReadme;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4791,6 +4791,27 @@
         "path": "^0.12.7",
         "remarkable": "^1.7.1",
         "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "autolinker": {
+          "version": "0.28.1",
+          "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.28.1.tgz",
+          "integrity": "sha1-BlK0kYgYefB3XazgzcoyM5QqTkc=",
+          "dev": true,
+          "requires": {
+            "gulp-header": "^1.7.1"
+          }
+        },
+        "remarkable": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.4.tgz",
+          "integrity": "sha512-e6NKUXgX95whv7IgddywbeN/ItCkWbISmc2DiqHJb0wTrqZIexqdco5b8Z3XZoo/48IdNVKM9ZCvTPJ4F5uvhg==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.10",
+            "autolinker": "~0.28.0"
+          }
+        }
       }
     },
     "agent-base": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",
@@ -89,6 +89,7 @@
     "postcss-scss": "^2.0.0",
     "puppeteer": "^1.19.0",
     "recursive-readdir": "^2.2.2",
+    "remarkable": "1.7.4",
     "request": "^2.88.2",
     "rimraf": "^3.0.2",
     "rollup-plugin-babel": "^4.4.0",


### PR DESCRIPTION
Extracted from a previous change https://github.com/hmrc/hmrc-frontend/pull/140/files

![listing-page-with-examples](https://user-images.githubusercontent.com/100650/128488187-5d043af7-436e-427d-b186-9fb622ff8c73.png)