### PR TITLE
Fixed flaky cookie test.

### DIFF
--- a/src/components/user-research-banner/user-research-banner.test.js
+++ b/src/components/user-research-banner/user-research-banner.test.js
@@ -66,7 +66,7 @@ describe('/components/user-research-banner', () => {
       expect(cookies[0].name).toEqual('mdtpurr');
       expect(cookies[0].value).toEqual('suppress_for_all_services');
       expect(cookies[0].expires).toBeGreaterThanOrEqual(earliestExpectedExpiry);
-      expect(cookies[0].expires).toBeGreaterThanOrEqual(latestExpectedExpiry);
+      expect(cookies[0].expires).toBeLessThanOrEqual(latestExpectedExpiry);
     });
   });
 });


### PR DESCRIPTION
This test would fail around 1 in 700 runs, an example of the error is:

```

> hmrc-frontend@2.2.2 lint
> stylelint 'src/**/*.scss' && eslint .


> hmrc-frontend@2.2.2 test
> npm run build:dist && jest src && npm run lint


> hmrc-frontend@2.2.2 build:dist
> gulp buildDist --destination 'dist' && npm run test:build:dist

[01:50:28] Using gulpfile ~/projects/opensource/hmrc/hmrc-frontend/gulpfile.js
[01:50:28] Starting 'buildDist'...
[01:50:28] Starting 'clean'...
[01:50:28] Finished 'clean' after 11 ms
[01:50:28] Starting 'copy-hmrc-images'...
[01:50:28] Finished 'copy-hmrc-images' after 35 ms
[01:50:28] Starting 'copy-govuk-images'...
[01:50:28] Finished 'copy-govuk-images' after 8.46 ms
[01:50:28] Starting 'copy-govuk-fonts'...
[01:50:28] Finished 'copy-govuk-fonts' after 4.96 ms
[01:50:28] Starting 'copy-html5shiv'...
[01:50:28] Finished 'copy-html5shiv' after 2.82 ms
[01:50:28] Starting 'scss:compile-all-govuk-and-hmrc'...
[01:50:29] Finished 'scss:compile-all-govuk-and-hmrc' after 1.48 s
[01:50:29] Starting 'js:compile-all-govuk-and-hmrc'...
[01:50:33] Finished 'js:compile-all-govuk-and-hmrc' after 3.61 s
[01:50:33] Starting 'update-assets-version'...
[01:50:33] Finished 'update-assets-version' after 310 μs
[01:50:33] Finished 'buildDist' after 5.16 s

> hmrc-frontend@2.2.2 test:build:dist
> jest tasks/gulp/__tests__/after-build-dist.test.js

Determining test suites to run...
Start Server
Server started at http://localhost:8888
Setup Puppeteer
 PASS  tasks/gulp/__tests__/after-build-dist.test.js
  dist/
    hmrc-frontend-2.2.2.min.css
      ✓ should not contain current media query displayed on body element (1ms)
    hmrc-frontend-ie8-2.2.2.min.css
      ✓ should not contain current media query displayed on body element

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        0.569s, estimated 1s
Ran all test suites matching /tasks\/gulp\/__tests__\/after-build-dist.test.js/i.
Teardown Puppeteer
Close server
Determining test suites to run...
Start Server
Server started at http://localhost:8888
Setup Puppeteer
Setup Test Environment.
Setup Test Environment.
Setup Test Environment.
Setup Test Environment.
 PASS  src/components/bundle.test.js
 PASS  src/components/timeout-dialog/timeout-dialog.test.js
Teardown Test Environment.
Setup Test Environment.
 PASS  src/components/language-select/template.test.js
 PASS  src/components/currency-input/template.test.js
 PASS  src/components/character-count/template.test.js
 PASS  src/components/add-to-a-list/template.test.js
 PASS  src/components/page-heading/template.test.js
 PASS  src/components/timeout-dialog/dialog.test.js
 PASS  src/components/account-menu/template.test.js
 PASS  src/components/timeout-dialog/timeout-dialog-integration.test.js
 FAIL  src/components/user-research-banner/user-research-banner.test.js
  ● /components/user-research-banner › When a page with the user research banner is loaded › should set the mdtpurr cookie with the correct properties when No thanks is clicked

    expect(received).toBeGreaterThanOrEqual(expected)

    Expected: >= 1633395038
    Received:    1633395037

      68 |       expect(cookies[0].value).toEqual('suppress_for_all_services');
      69 |       expect(cookies[0].expires).toBeGreaterThanOrEqual(earliestExpectedExpiry);
    > 70 |       expect(cookies[0].expires).toBeGreaterThanOrEqual(latestExpectedExpiry);
         |                                  ^
      71 |     });
      72 |   });
      73 | });

      at Object.<anonymous> (src/components/user-research-banner/user-research-banner.test.js:70:34)

Teardown Test Environment.
 PASS  src/components/new-tab-link/template.test.js
 PASS  src/components/banner/template.test.js
 PASS  src/components/notification-badge/template.test.js
 PASS  src/components/report-technical-issue/template.test.js
 PASS  src/components/account-menu/account-menu.mobile.test.js
 PASS  src/utils/__tests__/breakpoints.test.js
 PASS  src/components/internal-header/template.test.js
Teardown Test Environment.
 PASS  src/all.test.js
 PASS  src/components/user-research-banner/template.test.js
 PASS  src/utils/__tests__/cookies.test.js
 PASS  src/components/timeline/template.test.js
 PASS  src/components/footer/template.test.js
 PASS  src/components/header/template.test.js
 PASS  src/components/account-menu/account-menu.test.js
Teardown Test Environment.
 PASS  src/components/character-count/character-count.test.js
Teardown Test Environment.
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --runInBand --detectOpenHandles to find leaks.

Summary of all failing tests
 FAIL  src/components/user-research-banner/user-research-banner.test.js
  ● /components/user-research-banner › When a page with the user research banner is loaded › should set the mdtpurr cookie with the correct properties when No thanks is clicked

    expect(received).toBeGreaterThanOrEqual(expected)

    Expected: >= 1633395038
    Received:    1633395037

      68 |       expect(cookies[0].value).toEqual('suppress_for_all_services');
      69 |       expect(cookies[0].expires).toBeGreaterThanOrEqual(earliestExpectedExpiry);
    > 70 |       expect(cookies[0].expires).toBeGreaterThanOrEqual(latestExpectedExpiry);
         |                                  ^
      71 |     });
      72 |   });
      73 | });

      at Object.<anonymous> (src/components/user-research-banner/user-research-banner.test.js:70:34)


Test Suites: 1 failed, 25 passed, 26 total
Tests:       1 failed, 326 passed, 327 total
Snapshots:   7 passed, 7 total
Time:        5.462s
Ran all test suites matching /src/i.
Teardown Puppeteer
Close server
```