### PR TITLE
PLATUI-1365: update timeout dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.7.0] - 2021-10-06
+
+### Changed
+
+- Accessibility fixes to prevent users of some screen readers navigating outside an open timeout dialog.
+
 ## [2.6.0] - 2021-10-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/timeout-dialog/dialog.js
+++ b/src/components/timeout-dialog/dialog.js
@@ -2,7 +2,7 @@ import utils from './utils';
 import { nodeListForEach } from '../../common';
 
 function displayDialog($elementToDisplay) {
-  const $dialog = utils.generateDomElementFromString('<div id="hmrc-timeout-dialog" tabindex="-1" role="dialog" class="hmrc-timeout-dialog">');
+  const $dialog = utils.generateDomElementFromString('<div id="hmrc-timeout-dialog" tabindex="-1" role="dialog" aria-modal="true" class="hmrc-timeout-dialog">');
   const $overlay = utils.generateDomElementFromString('<div id="hmrc-timeout-overlay" class="hmrc-timeout-overlay">');
   const $preparedElementToDisplay = typeof $elementToDisplay === 'string' ? utils.generateDomElementFromString($elementToDisplay) : $elementToDisplay;
   const resetElementsFunctionList = [];
@@ -53,6 +53,9 @@ function displayDialog($elementToDisplay) {
     '#global-cookie-message',
     'main[role=main]',
     'body > footer',
+    'body > .govuk-skip-link',
+    '.cbanner-govuk-cookie-banner',
+    'body > .govuk-width-container',
   ];
   const elements = document.querySelectorAll(selectors.join(', '));
   const close = () => {

--- a/src/components/timeout-dialog/dialog.test.js
+++ b/src/components/timeout-dialog/dialog.test.js
@@ -75,6 +75,7 @@ describe('Dialog', () => {
       expect($dialog.classList).toContain('hmrc-timeout-dialog');
       expect($dialog.attributes.getNamedItem('role').value).toEqual('dialog');
       expect($dialog.attributes.getNamedItem('tabindex').value).toEqual('-1');
+      expect($dialog.attributes.getNamedItem('aria-modal').value).toEqual('true');
     });
 
     it('should be attached to the end of the body', () => {
@@ -190,6 +191,15 @@ describe('Dialog', () => {
       }
       if (!document.querySelector('body>footer')) {
         arr.push(utils.generateDomElementFromString('<footer>'));
+      }
+      if (!document.querySelector('body>.govuk-width-container')) {
+        arr.push(utils.generateDomElementFromString('<div class="govuk-width-container">'));
+      }
+      if (!document.querySelector('.cbanner-govuk-cookie-banner')) {
+        arr.push(utils.generateDomElementFromString('<div class="cbanner-govuk-cookie-banner">'));
+      }
+      if (!document.querySelector('body>.govuk-skip-link')) {
+        arr.push(utils.generateDomElementFromString('<a class="govuk-skip-link" href="#content">'));
       }
       arr.forEach(($elem) => document.body.appendChild($elem));
     });


### PR DESCRIPTION
Accessibility fixes to prevent users of some screen readers navigating outside an open timeout dialog.

- add extra selectors to be aria-hidden on open
- add aria-modal=true to the modal

Tested locally against gforms service https://jira.tools.tax.service.gov.uk/browse/PLATUI-1365?focusedCommentId=1453325&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1453325