### PR TITLE
PLATUI-1691: install better-npm-audit

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,8 @@
+{
+  "1067329": "devDependency, no risk given our usage",
+  "1067342": "devDependency, no risk given our usage",
+  "1067654": "devDependency, no risk given our usage",
+  "1070012": "devDependency, no risk given our usage",
+  "1070022": "devDependency, no risk given our usage",
+  "1070206": "devDependency, no risk given our usage"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3133,6 +3133,26 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "better-npm-audit": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/better-npm-audit/-/better-npm-audit-3.7.3.tgz",
+      "integrity": "sha512-zsSiidlP5n7KpCYdAmkellu4JYA4IoRUUwrBMv/R7TwT8vcRfk5CQ2zTg7yUy4bdWkKtAj7VVdPQttdMbx+n5Q==",
+      "dev": true,
+      "requires": {
+        "commander": "^8.0.0",
+        "dayjs": "^1.10.6",
+        "lodash.get": "^4.4.2",
+        "table": "^6.7.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+          "dev": true
+        }
+      }
+    },
     "binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -4518,6 +4538,12 @@
         "get-stdin": "*",
         "meow": "*"
       }
+    },
+    "dayjs": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.2.tgz",
+      "integrity": "sha512-F4LXf1OeU9hrSYRPTTj/6FbO4HTjPKXvEIC1P2kcnFurViINCVk3ZV0xAS3XVx9MkMsXbbqlK6hjseaYbgKEHw==",
+      "dev": true
     },
     "debug": {
       "version": "4.3.3",
@@ -9749,6 +9775,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.memoize": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:backstop": "gulp backstopTest",
     "test:backstop-approve": "gulp backstop:approve",
     "preinstall": "node check-compatibility.js",
-    "docs:generate-decision-log-listing": "adr-log -d ./docs/adr -i ./docs/adr/index.md -e template.md"
+    "docs:generate-decision-log-listing": "adr-log -d ./docs/adr -i ./docs/adr/index.md -e template.md",
+    "audit": "better-npm-audit audit"
   },
   "repository": {
     "type": "git",
@@ -45,6 +46,7 @@
     "govuk-frontend": "^4.0.1"
   },
   "devDependencies": {
+    "better-npm-audit": "^3.7.3",
     "@babel/preset-env": "^7.12.11",
     "adm-zip": "^0.5.5",
     "adr-log": "^2.2.0",


### PR DESCRIPTION
We're evaluating better-npm-audit as a way to keep track of npm security vulnerabilities separately from tooling like dependabot and npm audit. I've not bumped the version because this introduces no changes that should require a new version.

I've setup some exclusions for current issues with devDependencies that
we've checked and don't seem to be a risk with our usage. For most there's no
updated version we can use of our direct dependencies that addresses the
issue, and patching the transitive dependencies can break the usage or
introduce it's own security issues.