### PR TITLE
Integrating with new features of the prototype kit.

### DIFF
--- a/src/govuk-prototype-kit.config.json
+++ b/src/govuk-prototype-kit.config.json
@@ -4,14 +4,66 @@
     "/hmrc/components/banner/images",
     "/hmrc/components/internal-header/images"
   ],
-  "nunjucksPaths": [
-    "/"
-  ],
   "sass": [
     "/hmrc/_prototype-kit.scss"
   ],
   "scripts": [
     "/hmrc/all.js",
     "/hmrc/init-all.js"
+  ],
+  "importNunjucksMacrosInto": [
+    "/hmrc/templates/account-header.html"
+  ],
+  "templates": [
+    {
+      "name": "Blank page with Account Header",
+      "path": "/hmrc/templates/account-header.html",
+      "type": "nunjucks"
+    }
+  ],
+  "nunjucksPaths": [
+    "/"
+  ],
+  "nunjucksMacros": [
+    {
+      "macroName": "hmrcAccountMenu",
+      "importFrom": "hmrc/components/account-menu/macro.njk"
+    },
+    {
+      "macroName": "hmrcAddToAList",
+      "importFrom": "hmrc/components/add-to-a-list/macro.njk"
+    },
+    {
+      "macroName": "hmrcPageHeading",
+      "importFrom": "hmrc/components/page-heading/macro.njk"
+    },
+    {
+      "macroName": "hmrcBanner",
+      "importFrom": "hmrc/components/banner/macro.njk"
+    },
+    {
+      "macroName": "hmrcInternalHeader",
+      "importFrom": "hmrc/components/internal-header/macro.njk"
+    },
+    {
+      "macroName": "hmrcNotificationBadge",
+      "importFrom": "hmrc/components/notification-badge/macro.njk"
+    },
+    {
+      "macroName": "hmrcTimeoutDialog",
+      "importFrom": "hmrc/components/timeout-dialog/macro.njk"
+    },
+    {
+      "macroName": "hmrcHeader",
+      "importFrom": "hmrc/components/header/macro.njk"
+    },
+    {
+      "macroName": "hmrcTimeline",
+      "importFrom": "hmrc/components/timeline/macro.njk"
+    },
+    {
+      "macroName": "hmrcLanguageSelect",
+      "importFrom": "hmrc/components/language-select/macro.njk"
+    }
   ]
 }

--- a/src/layouts/account-header.html
+++ b/src/layouts/account-header.html
@@ -1,7 +1,4 @@
-{% extends "layout.html" %}
-
-{% from "../components/header/macro.njk" import hmrcHeader %}
-{% from "../components/account-menu/macro.njk" import hmrcAccountMenu %}
+{% extends "govuk-prototype-kit/layouts/govuk-branded.html" %}
 
 {% block header %}
   {{ hmrcHeader({

--- a/src/templates/account-header.html
+++ b/src/templates/account-header.html
@@ -1,0 +1,15 @@
+{% extends "hmrc/layouts/account-header.html" %}
+
+{% block pageTitle %}
+{{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    Your content goes here.
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This adds:

 - A template for account header which provides an easy way for users to create an account header page
 - Auto-importing of all components into the account header layout
 - Auto-importing of HMRC components (in any templates that are set up to auto-import)