### PR TITLE
PLAT-1959: Update report a problem template data to include the referrer url

### DIFF
--- a/src/components/report-technical-issue/report-technical-issue.yaml
+++ b/src/components/report-technical-issue/report-technical-issue.yaml
@@ -28,38 +28,47 @@ examples:
   data:
     serviceId: the-url-safe-service-id
     language: "en"
+    referrerUrl: "some-referrer-url"
 - name: with-deprecated-service-code
   data:
     serviceCode: the-url-safe-service-code
     language: "en"
+    referrerUrl: "some-referrer-url"
 - name: with-service-id-and-service-code
   data:
     serviceCode: the-url-safe-service-code
     serviceId: the-url-safe-service-id
     language: "en"
+    referrerUrl: "some-referrer-url"
 - name: welsh
   data:
     serviceId: the-url-safe-service-id
     language: "cy"
+    referrerUrl: "some-referrer-url"
 - name: with-classes
   data:
     serviceId: the-url-safe-service-id
     classes: govuk-!-font-weight-bold my-custom-class
     language: "cy"
+    referrerUrl: "some-referrer-url"
 - name: with-local-base-url
   data:
     serviceId: my-local-service
     baseUrl: http://localhost:9250
+    referrerUrl: "some-referrer-url"
 - name: with-production-base-url
   data:
     serviceId: my-production-service
     baseUrl: https://www.tax.service.gov.uk
+    referrerUrl: "some-referrer-url"
 - name: with-no-base-url
   data:
     serviceId: my-generic-service
+    referrerUrl: "some-referrer-url"
 - name: with-non-url-safe-service-id
   data:
     serviceId: Build & Deploy
+    referrerUrl: "some-referrer-url"
 - name: with-referrer-url
   data:
     serviceId: pay

--- a/src/components/report-technical-issue/template.test.js
+++ b/src/components/report-technical-issue/template.test.js
@@ -27,7 +27,7 @@ describe('Report Technical Issue', () => {
       expect($component.attr('target')).toEqual('_blank');
       expect($component.attr('hreflang')).toEqual('en');
       expect($component.attr('lang')).toEqual('en');
-      expect($component.attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=the-url-safe-service-id');
+      expect($component.attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=the-url-safe-service-id&referrerUrl=some-referrer-url');
       expect($component.text()).toEqual('Is this page not working properly? (opens in new tab)');
     });
   });
@@ -48,14 +48,14 @@ describe('Report Technical Issue', () => {
     const $ = render('report-technical-issue', examples['with-deprecated-service-code']);
 
     const $component = $('.govuk-link');
-    expect($component.attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=the-url-safe-service-code');
+    expect($component.attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=the-url-safe-service-code&referrerUrl=some-referrer-url');
   });
 
   it('uses the serviceId if serviceId and serviceCode are supplied', () => {
     const $ = render('report-technical-issue', examples['with-service-id-and-service-code']);
 
     const $component = $('.govuk-link');
-    expect($component.attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=the-url-safe-service-id');
+    expect($component.attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=the-url-safe-service-id&referrerUrl=some-referrer-url');
   });
 
   it('specify rel attributes as "noreferrer noopener" to prevent reverse tabnapping vulnerability', () => {
@@ -86,25 +86,25 @@ describe('Report Technical Issue', () => {
   it('should default to no Base URL', () => {
     const $ = render('report-technical-issue', examples['with-local-base-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('http://localhost:9250/contact/report-technical-problem?newTab=true&service=my-local-service');
+    expect($('.govuk-link').attr('href')).toEqual('http://localhost:9250/contact/report-technical-problem?newTab=true&service=my-local-service&referrerUrl=some-referrer-url');
   });
 
   it('should default to no Base URL', () => {
     const $ = render('report-technical-issue', examples['with-production-base-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('https://www.tax.service.gov.uk/contact/report-technical-problem?newTab=true&service=my-production-service');
+    expect($('.govuk-link').attr('href')).toEqual('https://www.tax.service.gov.uk/contact/report-technical-problem?newTab=true&service=my-production-service&referrerUrl=some-referrer-url');
   });
 
   it('should default to no Base URL', () => {
     const $ = render('report-technical-issue', examples['with-no-base-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=my-generic-service');
+    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=my-generic-service&referrerUrl=some-referrer-url');
   });
 
   it('should URL encode the service identifier', () => {
     const $ = render('report-technical-issue', examples['with-non-url-safe-service-id']);
 
-    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=Build%20%26%20Deploy');
+    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=Build%20%26%20Deploy&referrerUrl=some-referrer-url');
   });
 
   it('should URL encode the referrer url', () => {


### PR DESCRIPTION
As I am currently looking at the patched tests in **play-frontend-hmrc**, I found an inconsistency with the report a problem nunjucks template vs the hrmc twirl template. In the twirl template, the **rel** attribute is conditional whereas in the nunjucks template it's not and is always present. This causes us to patch the tests unnecessarily in **play-frontend-hmrc**, if we provide the referrer URL in the nunjucks examples we can then remove the patched tests in play-frontend-hmrc altogether.