### PR TITLE
NOJIRA: Stop accessible-autocomplete css including webfonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [5.11.1] - 2022-10-06
+
+### Fixed
+
+- Stopped the accessible-autocomplete css from including the GDS Transport webfonts because we assume they will already be loaded
+
 ## [5.11.0] - 2022-09-29
 
 ### Added
 
 - Added way to automatically enhance a select element into an [accessible-autocomplete](src/components/accessible-autocomplete) using the `data-module="hmrc-accessible-autocomplete"` data attribute, more details in the [accessible-autocomplete readme](src/components/accessible-autocomplete/README.md)
-
 
 ## [5.10.0] - 2022-09-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/accessible-autocomplete.scss
+++ b/src/accessible-autocomplete.scss
@@ -1,3 +1,5 @@
+$govuk-include-default-font-face: false;
+
 @import "../../govuk-frontend/govuk/settings/all";
 @import "../../govuk-frontend/govuk/tools/all";
 @import "../../govuk-frontend/govuk/helpers/all";


### PR DESCRIPTION
where we [import the helpers](https://github.com/hmrc/hmrc-frontend/blob/main/src/accessible-autocomplete.scss#L3) it's pulling in the [fonts](https://github.com/alphagov/govuk-frontend/blob/4b5ed0ada3b64722ae2074dfa0db5d4d3a45cb79/src/govuk/helpers/_font-faces.scss) - we need to set `$govuk-include-default-font-face: false;` ([which stops it from being pulled in when we use govuk-font()](https://github.com/alphagov/govuk-frontend/blob/e319f83cc2496e6814e0eb8f341ae658b05b415d/package/govuk/helpers/_typography.scss#L26-L28)) before we do the `@import` in that file to stop it. Because the font will already be available on the page via the main hmrc-frontend css