### PR TITLE
Using the govuk-branded layout for v13 kits.

### DIFF
--- a/src/layouts/account-header.html
+++ b/src/layouts/account-header.html
@@ -1,4 +1,8 @@
-{% extends "layout.html" %}
+{% if 'v13.' in releaseVersion %}
+  {% extends "layouts/main.html" %}
+{% else %}
+  {% extends "layout.html" %}
+{% endif %}
 
 {% from "../components/header/macro.njk" import hmrcHeader %}
 {% from "../components/account-menu/macro.njk" import hmrcAccountMenu %}

--- a/src/layouts/account-header.html
+++ b/src/layouts/account-header.html
@@ -1,5 +1,5 @@
 {% if 'v13.' in releaseVersion %}
-  {% extends "layouts/main.html" %}
+  {% extends "govuk-prototype-kit/layouts/govuk-branded.html" %}
 {% else %}
   {% extends "layout.html" %}
 {% endif %}


### PR DESCRIPTION
In v13 we've moved the main layout from `app/views/layout.html` to `app/views/layouts/main.html` which means that the Account Menu page doesn't actually work for v13 kits out of the box.

This PR extends the govuk-branded layout provided by the prototype kit when using v13.