### PR TITLE
PLATUI-2282

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [5.28.0] - 2023-04-20
+
+### Fixed
+
+- Updated timeout-dialog to fix bug. If user timed out and the timeout redirection took longer than a second then it
+  would get canceled and user would stay on page while the timeout dialog counted down into negative numbers.
+
 ## [5.27.0] - 2023-03-20
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "5.27.0",
+  "version": "5.28.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "5.27.0",
+  "version": "5.28.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/timeout-dialog/timeout-dialog-can-be-shown-multiple-times.test.js
+++ b/src/components/timeout-dialog/timeout-dialog-can-be-shown-multiple-times.test.js
@@ -10,6 +10,49 @@ import { installFakeTimersOnLoad, serveFakePage } from './test-helpers/browser-t
 import { version } from '../../../package.json';
 
 describe('timeout dialog with a single page open', () => {
+  it('should not keep counting down after timeout is reached', async () => {
+    jest.setTimeout(6000);
+
+    const page = await global.__BROWSER__.newPage();
+
+    await page.setRequestInterception(true);
+
+    page.on('request', (req) => {
+      if (req.url() === 'http://localhost:8888/timeout-reached') {
+        // simulate timeout page that's slower to respond that the 1-second tick of countdown timer
+        setTimeout(() => req.respond({
+          contentType: 'text/plain',
+          body: 'timeout page reached',
+        }), 2000);
+      } else if (req.url() === 'http://localhost:8888/') {
+        // subject of test needs to have a short timeout because we have to use real timers
+        req.respond({
+          contentType: 'text/html',
+          body: `
+            <meta name="hmrc-timeout-dialog"
+              content="hmrc-timeout-dialog"
+              data-timeout="2"
+              data-countdown="1"
+              data-keep-alive-url="?keepalive"
+              data-sign-out-url="/timeout-reached"
+              data-synchronise-tabs="true"/>
+            <link rel="stylesheet" href="/assets/hmrc-frontend-${version}.min.css">
+            <script src="/assets/hmrc-frontend-${version}.min.js"></script>
+          `,
+        });
+      } else {
+        req.continue();
+      }
+    });
+
+    await page.goto('http://localhost:8888/');
+
+    // now we need to wait until the slow timeout page should have loaded
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    expect(await page.content()).toContain('timeout page reached');
+  });
+
   it('should allow you to choose to continue your session more than once on the same page', async () => {
     const page = await global.__BROWSER__.newPage();
 

--- a/src/components/timeout-dialog/timeout-dialog-can-be-shown-multiple-times.test.js
+++ b/src/components/timeout-dialog/timeout-dialog-can-be-shown-multiple-times.test.js
@@ -9,10 +9,10 @@ import { installFakeTimersOnLoad, serveFakePage } from './test-helpers/browser-t
 
 import { version } from '../../../package.json';
 
+jest.setTimeout(10000);
+
 describe('timeout dialog with a single page open', () => {
   it('should not keep counting down after timeout is reached', async () => {
-    jest.setTimeout(6000);
-
     const page = await global.__BROWSER__.newPage();
 
     await page.setRequestInterception(true);

--- a/src/components/timeout-dialog/timeout-dialog.js
+++ b/src/components/timeout-dialog/timeout-dialog.js
@@ -266,12 +266,13 @@ function TimeoutDialog($module, $sessionActivityService) {
     };
 
     const runUpdate = () => {
-      const counter = getSecondsRemaining();
+      const counter = Math.max(getSecondsRemaining(), 0);
       updateCountdown(counter);
-      if (counter <= 0) {
+      if (counter === 0) {
         timeout();
+      } else {
+        currentTimer = window.setTimeout(runUpdate, getNextTimeout());
       }
-      currentTimer = window.setTimeout(runUpdate, getNextTimeout());
     };
 
     runUpdate();

--- a/src/components/timeout-dialog/timeout-dialog.test.js
+++ b/src/components/timeout-dialog/timeout-dialog.test.js
@@ -490,11 +490,11 @@ describe('/components/timeout-dialog', () => {
       pretendSecondsHavePassed(1);
 
       expect(redirectHelper.redirectToUrl).toHaveBeenCalledWith('timeout');
-      expect(getVisualCountText()).toEqual('time: -1 seconds.');
+      expect(getVisualCountText()).toEqual('time: 0 seconds.');
       expect(getAudibleCountText()).toEqual('time: 20 seconds.');
       pretendSecondsHavePassed(1);
 
-      expect(getVisualCountText()).toEqual('time: -2 seconds.');
+      expect(getVisualCountText()).toEqual('time: 0 seconds.');
       expect(getAudibleCountText()).toEqual('time: 20 seconds.');
     });
     it('should default redirectToUrl to data-sign-out-url if data-timeout-url is not set', () => {
@@ -591,11 +591,11 @@ describe('/components/timeout-dialog', () => {
       pretendSecondsHavePassed(1);
 
       expect(redirectHelper.redirectToUrl).toHaveBeenCalledWith('timeout');
-      expect(getVisualCountText()).toEqual('Welsh, time: -1 eiliad.');
+      expect(getVisualCountText()).toEqual('Welsh, time: 0 eiliad.');
       expect(getAudibleCountText()).toEqual('Welsh, time: 20 eiliad.');
       pretendSecondsHavePassed(1);
 
-      expect(getVisualCountText()).toEqual('Welsh, time: -2 eiliad.');
+      expect(getVisualCountText()).toEqual('Welsh, time: 0 eiliad.');
       expect(getAudibleCountText()).toEqual('Welsh, time: 20 eiliad.');
     });
 
@@ -703,11 +703,11 @@ describe('/components/timeout-dialog', () => {
       pretendSecondsHavePassed(1);
 
       expect(redirectHelper.redirectToUrl).toHaveBeenCalledWith('timeout');
-      expect(getVisualCountText()).toEqual('Remaining time is -1 seconds.');
+      expect(getVisualCountText()).toEqual('Remaining time is 0 seconds.');
       expect(getAudibleCountText()).toEqual(lowestAudibleCount);
       pretendSecondsHavePassed(1);
 
-      expect(getVisualCountText()).toEqual('Remaining time is -2 seconds.');
+      expect(getVisualCountText()).toEqual('Remaining time is 0 seconds.');
       expect(getAudibleCountText()).toEqual(lowestAudibleCount);
     });
   });


### PR DESCRIPTION
When timeout is reached, it will keep counting down past 0 and if the
timeout page takes longer than the 1-second tick then the timeout
redirection gets cancelled. Instead when the timeout is reached we want
to stop doing anything and let the timeout redirection happen.