### PR TITLE
Add pluginDependencies to govuk-prototype-kit.config.json

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint
+
+node lib/update-govuk-prototype-kit-config.js
+
+git add src/govuk-prototype-kit.config.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+git-tag-version=false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,21 @@ You can:
 
 ## Before you create a pull request
 
+### Run `npm install` and make sure you've updated the version number
+
+Running the following will:
+- make sure any changes to your package.json are reflected in your package-lock.json
+- make sure pre-commit hooks are installed and deps needed to run their checks are available
+- bump the version number in your package.json and package-lock.json
+
+> **Warning:**
+> Make sure you commit the changes!
+
+```
+npm install
+npm version minor
+```
+
 ### Adding or updating NPM dependencies
 
 To minimise the security risk from accidentally installing a compromised package, you should:

--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ You can also create a pull request to contribute to HMRC Frontend. See our [cont
 ## License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").
+

--- a/lib/update-govuk-prototype-kit-config.js
+++ b/lib/update-govuk-prototype-kit-config.js
@@ -1,0 +1,14 @@
+const path = require('path');
+const fs = require('fs');
+
+const projectDir = path.dirname(__dirname);
+const govukFrontendVersion = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), 'utf8')).dependencies['govuk-frontend'].replace(/[^0-9.]/g, '');
+const govukPrototypeKitConfigPath = path.join(projectDir, 'src', 'govuk-prototype-kit.config.json');
+const govukPrototypeKitConfig = JSON.parse(fs.readFileSync(govukPrototypeKitConfigPath, 'utf8'));
+govukPrototypeKitConfig.pluginDependencies = [
+  {
+    packageName: 'govuk-frontend',
+    minVersion: govukFrontendVersion,
+  },
+];
+fs.writeFileSync(govukPrototypeKitConfigPath, JSON.stringify(govukPrototypeKitConfig, null, 2));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "5.42.0",
+  "version": "5.43.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9500,6 +9500,12 @@
       "requires": {
         "ms": "^2.0.0"
       }
+    },
+    "husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "5.42.0",
+  "version": "5.43.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",
@@ -20,7 +20,8 @@
     "test:backstop": "gulp backstopTest",
     "test:backstop-approve": "gulp backstop:approve",
     "docs:generate-decision-log-listing": "adr-log -d ./docs/adr -i ./docs/adr/index.md -e template.md",
-    "audit": "better-npm-audit audit"
+    "audit": "better-npm-audit audit",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
@@ -75,6 +76,7 @@
     "gulp-sourcemaps": "^3.0.0",
     "gulp-uglify-es": "^3.0.0",
     "html5shiv": "^3.7.3",
+    "husky": "^8.0.3",
     "jest": "^27.5.1",
     "jest-axe": "^3.5.0",
     "jest-environment-node": "^26.6.2",
@@ -123,11 +125,5 @@
     "testRunner": "jest-jasmine2",
     "globalSetup": "./lib/puppeteer/setup.js",
     "globalTeardown": "./lib/puppeteer/teardown.js"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run lint",
-      "pre-push": "npm test"
-    }
   }
 }

--- a/src/govuk-prototype-kit.config.json
+++ b/src/govuk-prototype-kit.config.json
@@ -1,4 +1,10 @@
 {
+  "pluginDependencies": [
+    {
+      "packageName": "govuk-frontend",
+      "minVersion": "4.7.0"
+    }
+  ],
   "assets": [
     "/hmrc/components/account-menu/images",
     "/hmrc/components/banner/images",


### PR DESCRIPTION
Prompted by @nataliecarey 🙌 this helps ensure that people installing hmrc-frontend via the govuk-prototype-kit management interface also get govuk-frontend

Turning off the git commit & tag behaviour of `npm version minor` doesn't impact our release process because we tag releases in a different way.