### PR TITLE
Added plugin metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",
-    "test:build:package": "jest tasks/gulp/__tests__/after-build-package.test.js",
+    "test:build:package": "jest tasks/gulp/__tests__/after-build-package.test.js && npx govuk-prototype-kit@latest validate-plugin package",
     "test:build:dist": "jest tasks/gulp/__tests__/after-build-dist.test.js",
     "test:build:webjar": "jest tasks/gulp/__tests__/after-build-webjar.test.js",
     "build:package": "gulp buildPackage --destination 'package' && npm run test:build:package",

--- a/src/govuk-prototype-kit.config.json
+++ b/src/govuk-prototype-kit.config.json
@@ -1,4 +1,12 @@
 {
+  "meta": {
+    "description": "HMRC Frontend contains the code and documentation for patterns specifically designed for HMRC.",
+    "urls": {
+      "documentation": "https://design.tax.service.gov.uk/hmrc-design-patterns/",
+      "releaseNotes": "https://github.com/hmrc/hmrc-frontend/releases/tag/v{{version}}",
+      "versionHistory": "https://github.com/hmrc/hmrc-frontend/releases"
+    }
+  },
   "pluginDependencies": [
     {
       "packageName": "govuk-frontend",


### PR DESCRIPTION
We're working on a new plugin page, we'll be making use of new metadata that comes from plugin config.  This PR adds that metadata.

I've also added the validator to the post-build tests, this uses `npx` and `@latest` to always look at the latest requirements.  I recommend this approach but it does erode the purity of repeatable builds, you could hardcode a version number in there or install `govuk-prototype-kit` as a (dev) dependency and remove both `npx` and `@latest`.