### PR TITLE
Proof of concept: migrate to dart-sass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "rollup-plugin-babel": "^4.4.0",
         "rollup-plugin-commonjs": "^10.1.0",
         "rollup-plugin-node-resolve": "^5.2.0",
+        "sass": "^1.77.8",
         "standard": "^17.0.0",
         "stylelint": "^13.13.1",
         "stylelint-config-standard": "^20.0.0",
@@ -12499,6 +12500,12 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "node_modules/immutable": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
+      "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
+      "dev": true
+    },
     "node_modules/import-fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -21459,6 +21466,23 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/sass": {
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
+      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/sass-graph": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   },
   "homepage": "https://github.com/hmrc/hmrc-frontend#readme",
   "dependencies": {
-    "govuk-frontend": "^5.3.0",
-    "accessible-autocomplete": "^2.0.4"
+    "accessible-autocomplete": "^2.0.4",
+    "govuk-frontend": "^5.3.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",
@@ -100,6 +100,7 @@
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
+    "sass": "^1.77.8",
     "standard": "^17.0.0",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^20.0.0",

--- a/tasks/gulp/compile-scss.js
+++ b/tasks/gulp/compile-scss.js
@@ -1,5 +1,5 @@
 const gulp = require('gulp');
-const sass = require('gulp-sass')(require('node-sass'));
+const sass = require('gulp-sass')(require('sass'));
 const plumber = require('gulp-plumber');
 const postcss = require('gulp-postcss');
 const autoprefixer = require('autoprefixer');
@@ -22,7 +22,7 @@ gulp.task('scss:compile-all-govuk-and-hmrc', () => gulp.src(`${configPaths.src}a
   .pipe(plumber(errorHandler))
   .pipe(sourcemaps.init())
   .pipe(sass({
-    includePaths: ['node_modules'],
+    includePaths: ['node_modules', 'node_modules/govuk-frontend/dist', 'node_modules/govuk-frontend/dist/govuk/components'],
   }))
   // minify css add vendor prefixes and normalize to compiled css
   .pipe(postcss([
@@ -40,7 +40,7 @@ gulp.task('scss:compile-accessible-autocomplete', () => gulp.src(`${configPaths.
   .pipe(plumber(errorHandler))
   .pipe(sourcemaps.init())
   .pipe(sass({
-    includePaths: ['node_modules'],
+    includePaths: ['node_modules', 'node_modules/govuk-frontend/dist', 'node_modules/govuk-frontend/dist/govuk/components'],
   }))
 // minify css add vendor prefixes and normalize to compiled css
   .pipe(postcss([


### PR DESCRIPTION
The key bit of this proof of concept is that by bodging the includePaths we've made it so that we get the behaviour we had before from libsass which means we don't need to change the relative imports we have in our sass paths that will require sass load paths be updated by consumers. Where some of our consumers are using different ways of loading packages and they won't always be in node_modules folder, and some don't have the option of updating their load paths (govuk prototype kit) users.