### PR TITLE
PLATUI-3035 remove unused report-technical-problem url param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.25.0] - 2024-07-17
+
+### Changed
+
+- Removed unused url parameter `newTab=true` from `report-technical-problem` component, to ease maintaining the component
+
 ## [6.24.0] - 2024-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.24.0",
+  "version": "6.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.24.0",
+      "version": "6.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.24.0",
+  "version": "6.25.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/report-technical-issue/template.njk
+++ b/src/components/report-technical-issue/template.njk
@@ -1,9 +1,9 @@
 {% set language %}{% if params.language == 'cy' %}cy{% else %}en{% endif %}{% endset %}
 {% set serviceId = params.serviceId or params.serviceCode %}
 {% set urlParametersBuilder %}
-  {% if serviceId %}?service={{ serviceId | urlencode }}{% endif %}
+  {% if params.referrerUrl or serviceId %}?{% endif %}
+  {% if serviceId %}service={{ serviceId | urlencode }}{% endif %}
   {% if params.referrerUrl and serviceId %}&amp;{% endif %}
-  {% if params.referrerUrl and not serviceId %}?{% endif %}
   {% if params.referrerUrl %}referrerUrl={{ params.referrerUrl | urlencode }}{% endif %}
 {% endset %}
 <a lang="{{ language }}" hreflang="{{ language }}"

--- a/src/components/report-technical-issue/template.njk
+++ b/src/components/report-technical-issue/template.njk
@@ -4,5 +4,5 @@
   class="govuk-link hmrc-report-technical-issue {{ params.classes }}"
   {% if params.referrerUrl %} rel="noreferrer noopener"{% endif %}
   target="_blank"
-  href="{{ params.baseUrl }}/contact/report-technical-problem?newTab=true{% if serviceId %}&amp;service={{ serviceId | urlencode }}{% endif %}{% if params.referrerUrl %}&amp;referrerUrl={{ params.referrerUrl | urlencode }}{% endif %}"
+  href="{{ params.baseUrl }}/contact/report-technical-problem{% if serviceId or params.referrerUrl %}?{% endif %}{% if serviceId %}service={{ serviceId | urlencode }}{% endif %}{% if params.referrerUrl %}&amp;referrerUrl={{ params.referrerUrl | urlencode }}{% endif %}"
 >{% if params.language == 'cy' %}A yw’r dudalen hon yn gweithio’n iawn? (yn agor tab newydd){% else %}Is this page not working properly? (opens in new tab){% endif %}</a>

--- a/src/components/report-technical-issue/template.njk
+++ b/src/components/report-technical-issue/template.njk
@@ -1,8 +1,14 @@
 {% set language %}{% if params.language == 'cy' %}cy{% else %}en{% endif %}{% endset %}
 {% set serviceId = params.serviceId or params.serviceCode %}
+{% set urlParametersBuilder %}
+  {% if serviceId %}?service={{ serviceId | urlencode }}{% endif %}
+  {% if params.referrerUrl and serviceId %}&amp;{% endif %}
+  {% if params.referrerUrl and not serviceId %}?{% endif %}
+  {% if params.referrerUrl %}referrerUrl={{ params.referrerUrl | urlencode }}{% endif %}
+{% endset %}
 <a lang="{{ language }}" hreflang="{{ language }}"
   class="govuk-link hmrc-report-technical-issue {{ params.classes }}"
   {% if params.referrerUrl %} rel="noreferrer noopener"{% endif %}
   target="_blank"
-  href="{{ params.baseUrl }}/contact/report-technical-problem{% if serviceId or params.referrerUrl %}?{% endif %}{% if serviceId %}service={{ serviceId | urlencode }}{% endif %}{% if params.referrerUrl %}&amp;referrerUrl={{ params.referrerUrl | urlencode }}{% endif %}"
+  href="{{ params.baseUrl }}/contact/report-technical-problem{{urlParametersBuilder}}"
 >{% if params.language == 'cy' %}A yw’r dudalen hon yn gweithio’n iawn? (yn agor tab newydd){% else %}Is this page not working properly? (opens in new tab){% endif %}</a>

--- a/src/components/report-technical-issue/template.test.js
+++ b/src/components/report-technical-issue/template.test.js
@@ -111,13 +111,13 @@ describe('Report Technical Issue', () => {
   it('should URL encode the referrer url', () => {
     const $ = render('report-technical-issue', examples['with-referrer-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=pay&referrerUrl=https%3A%2F%2Fwww.tax.service.gov.uk%2Fpay%3Fabc%3Ddef');
+    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=pay&amp;referrerUrl=https%3A%2F%2Fwww.tax.service.gov.uk%2Fpay%3Fabc%3Ddef');
   });
 
   it('should URL encode the local referrer url', () => {
     const $ = render('report-technical-issue', examples['with-local-referrer-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=pay&referrerUrl=http%3A%2F%2Flocalhost%3A9123%2Fmy-service');
+    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=pay&amp;referrerUrl=http%3A%2F%2Flocalhost%3A9123%2Fmy-service');
   });
 
   it('should include a rel="noreferrer noopener" attribute if the referrerUrl is explicitly passed', () => {

--- a/src/components/report-technical-issue/template.test.js
+++ b/src/components/report-technical-issue/template.test.js
@@ -27,7 +27,7 @@ describe('Report Technical Issue', () => {
       expect($component.attr('target')).toEqual('_blank');
       expect($component.attr('hreflang')).toEqual('en');
       expect($component.attr('lang')).toEqual('en');
-      expect($component.attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=the-url-safe-service-id');
+      expect($component.attr('href')).toEqual('/contact/report-technical-problem?service=the-url-safe-service-id');
       expect($component.text()).toEqual('Is this page not working properly? (opens in new tab)');
     });
   });
@@ -40,7 +40,7 @@ describe('Report Technical Issue', () => {
     expect($component.attr('target')).toEqual('_blank');
     expect($component.attr('hreflang')).toEqual('en');
     expect($component.attr('lang')).toEqual('en');
-    expect($component.attr('href')).toEqual('/contact/report-technical-problem?newTab=true');
+    expect($component.attr('href')).toEqual('/contact/report-technical-problem');
     expect($component.text()).toEqual('Is this page not working properly? (opens in new tab)');
   });
 
@@ -48,14 +48,14 @@ describe('Report Technical Issue', () => {
     const $ = render('report-technical-issue', examples['with-deprecated-service-code']);
 
     const $component = $('.govuk-link');
-    expect($component.attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=the-url-safe-service-code');
+    expect($component.attr('href')).toEqual('/contact/report-technical-problem?service=the-url-safe-service-code');
   });
 
   it('uses the serviceId if serviceId and serviceCode are supplied', () => {
     const $ = render('report-technical-issue', examples['with-service-id-and-service-code']);
 
     const $component = $('.govuk-link');
-    expect($component.attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=the-url-safe-service-id');
+    expect($component.attr('href')).toEqual('/contact/report-technical-problem?service=the-url-safe-service-id');
   });
 
   it('renders link with fixed classes', () => {
@@ -87,37 +87,37 @@ describe('Report Technical Issue', () => {
   it('should default to no Base URL', () => {
     const $ = render('report-technical-issue', examples['with-local-base-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('http://localhost:9250/contact/report-technical-problem?newTab=true&service=my-local-service');
+    expect($('.govuk-link').attr('href')).toEqual('http://localhost:9250/contact/report-technical-problem?service=my-local-service');
   });
 
   it('should default to no Base URL', () => {
     const $ = render('report-technical-issue', examples['with-production-base-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('https://www.tax.service.gov.uk/contact/report-technical-problem?newTab=true&service=my-production-service');
+    expect($('.govuk-link').attr('href')).toEqual('https://www.tax.service.gov.uk/contact/report-technical-problem?service=my-production-service');
   });
 
   it('should default to no Base URL', () => {
     const $ = render('report-technical-issue', examples['with-no-base-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=my-generic-service');
+    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=my-generic-service');
   });
 
   it('should URL encode the service identifier', () => {
     const $ = render('report-technical-issue', examples['with-non-url-safe-service-id']);
 
-    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=Build%20%26%20Deploy');
+    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=Build%20%26%20Deploy');
   });
 
   it('should URL encode the referrer url', () => {
     const $ = render('report-technical-issue', examples['with-referrer-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=pay&referrerUrl=https%3A%2F%2Fwww.tax.service.gov.uk%2Fpay%3Fabc%3Ddef');
+    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=pay&referrerUrl=https%3A%2F%2Fwww.tax.service.gov.uk%2Fpay%3Fabc%3Ddef');
   });
 
   it('should URL encode the local referrer url', () => {
     const $ = render('report-technical-issue', examples['with-local-referrer-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?newTab=true&service=pay&referrerUrl=http%3A%2F%2Flocalhost%3A9123%2Fmy-service');
+    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=pay&referrerUrl=http%3A%2F%2Flocalhost%3A9123%2Fmy-service');
   });
 
   it('should include a rel="noreferrer noopener" attribute if the referrerUrl is explicitly passed', () => {


### PR DESCRIPTION
# Purpose of PR
- To remove an unused url parameter from the report-technical-problem component
- Update all tests 