### PR TITLE
PLATUI-3035 remove hard-coded amp; value in unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.26.0] - 2024-07-18
+
+### Changed
+
+- Remove unit test reliance on hard-coded `amp;` encoding within `report-technical-problem` component
+- Inline the url string for `report-technical-problem`
+
 ## [6.25.0] - 2024-07-17
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.25.0",
+  "version": "6.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.25.0",
+      "version": "6.26.0",
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.25.0",
+  "version": "6.26.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/report-technical-issue/template.njk
+++ b/src/components/report-technical-issue/template.njk
@@ -1,14 +1,8 @@
 {% set language %}{% if params.language == 'cy' %}cy{% else %}en{% endif %}{% endset %}
 {% set serviceId = params.serviceId or params.serviceCode %}
-{% set urlParametersBuilder %}
-  {% if params.referrerUrl or serviceId %}?{% endif %}
-  {% if serviceId %}service={{ serviceId | urlencode }}{% endif %}
-  {% if params.referrerUrl and serviceId %}&amp;{% endif %}
-  {% if params.referrerUrl %}referrerUrl={{ params.referrerUrl | urlencode }}{% endif %}
-{% endset %}
 <a lang="{{ language }}" hreflang="{{ language }}"
   class="govuk-link hmrc-report-technical-issue {{ params.classes }}"
   {% if params.referrerUrl %} rel="noreferrer noopener"{% endif %}
   target="_blank"
-  href="{{ params.baseUrl }}/contact/report-technical-problem{{urlParametersBuilder}}"
+  href="{{ params.baseUrl }}/contact/report-technical-problem{% if params.referrerUrl or serviceId %}?{% endif %}{% if serviceId %}service={{ serviceId | urlencode }}{% endif %}{% if params.referrerUrl and serviceId -%}&amp;{%- endif %}{% if params.referrerUrl %}referrerUrl={{ params.referrerUrl | urlencode }}{% endif %}"
 >{% if params.language == 'cy' %}A yw’r dudalen hon yn gweithio’n iawn? (yn agor tab newydd){% else %}Is this page not working properly? (opens in new tab){% endif %}</a>

--- a/src/components/report-technical-issue/template.test.js
+++ b/src/components/report-technical-issue/template.test.js
@@ -111,13 +111,13 @@ describe('Report Technical Issue', () => {
   it('should URL encode the referrer url', () => {
     const $ = render('report-technical-issue', examples['with-referrer-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=pay&amp;referrerUrl=https%3A%2F%2Fwww.tax.service.gov.uk%2Fpay%3Fabc%3Ddef');
+    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=pay&referrerUrl=https%3A%2F%2Fwww.tax.service.gov.uk%2Fpay%3Fabc%3Ddef');
   });
 
   it('should URL encode the local referrer url', () => {
     const $ = render('report-technical-issue', examples['with-local-referrer-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=pay&amp;referrerUrl=http%3A%2F%2Flocalhost%3A9123%2Fmy-service');
+    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=pay&referrerUrl=http%3A%2F%2Flocalhost%3A9123%2Fmy-service');
   });
 
   it('should include a rel="noreferrer noopener" attribute if the referrerUrl is explicitly passed', () => {

--- a/src/components/report-technical-issue/template.test.js
+++ b/src/components/report-technical-issue/template.test.js
@@ -111,13 +111,13 @@ describe('Report Technical Issue', () => {
   it('should URL encode the referrer url', () => {
     const $ = render('report-technical-issue', examples['with-referrer-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=pay&referrerUrl=https%3A%2F%2Fwww.tax.service.gov.uk%2Fpay%3Fabc%3Ddef');
+    expect($('.govuk-link').prop('outerHTML')).toContain('href="/contact/report-technical-problem?service=pay&amp;referrerUrl=https%3A%2F%2Fwww.tax.service.gov.uk%2Fpay%3Fabc%3Ddef"');
   });
 
   it('should URL encode the local referrer url', () => {
     const $ = render('report-technical-issue', examples['with-local-referrer-url']);
 
-    expect($('.govuk-link').attr('href')).toEqual('/contact/report-technical-problem?service=pay&referrerUrl=http%3A%2F%2Flocalhost%3A9123%2Fmy-service');
+    expect($('.govuk-link').prop('outerHTML')).toContain('href="/contact/report-technical-problem?service=pay&amp;referrerUrl=http%3A%2F%2Flocalhost%3A9123%2Fmy-service"');
   });
 
   it('should include a rel="noreferrer noopener" attribute if the referrerUrl is explicitly passed', () => {


### PR DESCRIPTION
# Purpose of PR
- We uncovered the way we were rendering special characters are different in `hmrc-frontend` to `play-frontend-hmrc`
- To ensure consistency, changed the url parameter string back to inline
- Extra work to be carried out to ensure we are correctly comparing environments