### PR TITLE
PLATUI-3262 bump govuk-frontend version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.31.0] - 2024-09-11
+
+### Changed
+
+- Updated govuk-frontend to v5.6.0
+
 ## [6.30.0] - 2024-09-03
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.30.0",
+  "version": "6.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.29.0",
+      "version": "6.31.0",
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^2.0.4",
-        "govuk-frontend": "^5.5.0"
+        "govuk-frontend": "^5.6.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
@@ -11315,9 +11315,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.5.0.tgz",
-      "integrity": "sha512-lNSHCOzgk6LfgelcdtJxTLK1BX/cpjCUyEB3LnzliD9o9YQckNMsbj5+jSOs2RFy6XBJ/DJqxj2TKfjBCuzpyA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.6.0.tgz",
+      "integrity": "sha512-yNA4bL7i7mNrg36wPNZ3RctHo9mjl82Phs8MWs1lwovxJuQ4ogEo/XWn2uB1HxkXNqgMlW4wnd0iiKgRMfxYfw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.30.0",
+  "version": "6.31.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/hmrc/hmrc-frontend#readme",
   "dependencies": {
-    "govuk-frontend": "^5.5.0",
+    "govuk-frontend": "^5.6.0",
     "accessible-autocomplete": "^2.0.4"
   },
   "devDependencies": {

--- a/src/govuk-prototype-kit.config.json
+++ b/src/govuk-prototype-kit.config.json
@@ -10,7 +10,7 @@
   "pluginDependencies": [
     {
       "packageName": "govuk-frontend",
-      "minVersion": "5.5.0"
+      "minVersion": "5.6.0"
     }
   ],
   "assets": [


### PR DESCRIPTION
# Purpose of PR
- Bump govuk-frontend version to `latest` (v5.6.0)
- Bump `hmrc-frontend` version to `6.31.0`
- Update the CHANGELOG