### PR TITLE
Update npm audit exception

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -12,5 +12,6 @@
   "GHSA-grv7-fg5c-xmjg": "devDependency, should be no risk, but if we did hit an issue it would just result in long build we might have to kill and fix.",
   "GHSA-952p-6rrq-rcjv": "micromatch: used by stylelint, no risk given our usage",
   "GHSA-gcx4-mw62-g8wm": "rollup - we don't use import.meta.url to inject scripts dynamically, so we should be ok",
-  "GHSA-3h5v-q93c-6h6q": "backstopjs - won't impact us I think, and we can't upgrade past at the moment because of flakey tests."
+  "GHSA-3h5v-q93c-6h6q": "backstopjs - won't impact us I think, and we can't upgrade past at the moment because of flakey tests.",
+  "GHSA-pxg6-pf52-xh8x": "cookie - this is transitive dep of express, which we just use locally and don't use to set cookies."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.37.0] - 2024-10-23
+
+### Changed
+
+- updated npm audit exceptions
+
 ## [6.36.0] - 2024-10-22
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.36.0",
+  "version": "6.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.36.0",
+      "version": "6.37.0",
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.36.0",
+  "version": "6.37.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",


### PR DESCRIPTION
did it as a version bump to avoid failed build, as our build pipeline tries to build a release of each change