### PR TITLE
use govuk-focus-colour for timeout-dialog over default browser colour

### DIFF
--- a/src/components/timeout-dialog/_timeout-dialog.scss
+++ b/src/components/timeout-dialog/_timeout-dialog.scss
@@ -38,6 +38,10 @@ html {
   @include govuk-media-query($from: tablet) {
     width: 435px;
   }
+
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+  }
 }
 
 .hmrc-timeout-dialog__message {


### PR DESCRIPTION
The timeout-dialog appears with keyboard focus but is styled with the focus browser default. This is inconsistent with govuk styles but may also have insufficent contrast in some browsers, so I've made this small change to use the govuk style.

Resolves https://github.com/hmrc/hmrc-frontend/issues/388

Preview for Firefox 131.0.3 (macOS)

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/e3c3168d-a2cf-4a75-97bd-96abe9ba485d)|![image](https://github.com/user-attachments/assets/1e3abcf3-2073-4b3d-8ed4-9544268f22ae) | 