### PR TITLE
put timeout-dialog ctas in .button-group to align size and font baseline

### DIFF
--- a/src/components/timeout-dialog/_timeout-dialog.scss
+++ b/src/components/timeout-dialog/_timeout-dialog.scss
@@ -52,25 +52,13 @@ html {
   white-space: nowrap;
 }
 
-.hmrc-timeout-dialog__link-wrapper {
-  @include govuk-media-query($from: tablet) {
-    display: inline-block;
-    line-height: 2.5em;
-    vertical-align: baseline;
-  }
-}
-
 .hmrc-timeout-dialog__link {
   @include govuk-font($size: 24);
-
-  display: inline-block;
 
   @include govuk-media-query($from: tablet) {
     @include govuk-font($size: 19);
 
-    position: relative;
-    top: 2px;
-    padding: 0.526315em 0.789473em 0.263157em;
-    line-height: 1.5;
+    // Same padding as govuk-button
+    padding: (govuk-spacing(2) - $govuk-border-width-form-element) govuk-spacing(2) (govuk-spacing(2) - $govuk-border-width-form-element - ($govuk-border-width-form-element / 2));
   }
 }

--- a/src/components/timeout-dialog/timeout-dialog.js
+++ b/src/components/timeout-dialog/timeout-dialog.js
@@ -141,14 +141,6 @@ function TimeoutDialog($module, $sessionActivityService) {
     });
   };
 
-  const wrapLink = ($elem) => {
-    const $wrapper = document.createElement('div');
-    $wrapper.classList.add('hmrc-timeout-dialog__link-wrapper');
-    $wrapper.appendChild($elem);
-
-    return $wrapper;
-  };
-
   const setupDialog = (signoutTime) => {
     const $element = utils.generateDomElementFromString('<div>');
 
@@ -181,9 +173,12 @@ function TimeoutDialog($module, $sessionActivityService) {
       settings.keepAliveButtonText,
     );
 
+    const $wrapper = document.createElement('div');
+    $wrapper.classList.add('govuk-button-group');
+    $wrapper.appendChild($staySignedInButton);
+
     $element.appendChild($visualMessge);
     $element.appendChild($audibleMessage);
-    $element.appendChild($staySignedInButton);
     $staySignedInButton.addEventListener('click', keepAliveAndClose);
     $element.appendChild(document.createTextNode(' '));
 
@@ -195,8 +190,10 @@ function TimeoutDialog($module, $sessionActivityService) {
       $signOutButton.addEventListener('click', signOut);
       $signOutButton.setAttribute('href', settings.signOutUrl);
 
-      $element.appendChild(wrapLink($signOutButton));
+      $wrapper.appendChild($signOutButton);
     }
+
+    $element.appendChild($wrapper);
 
     const dialogControl = dialog.displayDialog($element);
 

--- a/src/components/timeout-dialog/timeout-dialog.jsdom.test.js
+++ b/src/components/timeout-dialog/timeout-dialog.jsdom.test.js
@@ -183,8 +183,10 @@ describe('/components/timeout-dialog', () => {
       expect(testScope.latestDialog$element.querySelector('#hmrc-timeout-sign-out-link').innerText).toEqual('Sign out');
     });
 
-    it('should separate the call-to-actions into different containers', () => {
-      expect(testScope.latestDialog$element.querySelector('button#hmrc-timeout-keep-signin-btn.govuk-button').parentNode).not.toBe(testScope.latestDialog$element.querySelector('#hmrc-timeout-sign-out-link').parentNode);
+    it('should add the call-to-actions into a shared button-group container', () => {
+      const group = testScope.latestDialog$element.querySelector('.govuk-button-group');
+      expect(testScope.latestDialog$element.querySelector('button#hmrc-timeout-keep-signin-btn.govuk-button').parentNode).toBe(group);
+      expect(testScope.latestDialog$element.querySelector('#hmrc-timeout-sign-out-link').parentNode).toBe(group);
     });
 
     it('should redirect to sign out url when sign out is clicked', () => {


### PR DESCRIPTION
Moving the timeout CTAs into a [govuk-button-group](https://design-system.service.gov.uk/components/button/#grouping-buttons) so that the text baseline is consistent.

I've kept the link touch area large by emulating the padding of the button.

Preview in Firefox 131.0.3 (macOS)

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/4ea0da86-a6df-4297-92a5-0894fb97fe49) | ![image](https://github.com/user-attachments/assets/033c8890-7845-4532-99e7-99fca51876f1) |
| ![image](https://github.com/user-attachments/assets/099b874e-d144-4097-a93d-41261133154b) | ![image](https://github.com/user-attachments/assets/50d5e3c8-bec8-4bf5-b501-752481a7e4b8) |
| ![image](https://github.com/user-attachments/assets/ed630746-334c-4ed1-b0c1-d4bf9a43be3e) | ![image](https://github.com/user-attachments/assets/adbf6a1a-79eb-4ba6-a33a-00bb3bb825c5) | 