### PR TITLE
add govuk-link style to "View the readme" links on app index page

### DIFF
--- a/app/views/layouts/index.njk
+++ b/app/views/layouts/index.njk
@@ -11,7 +11,7 @@
       <p class="govuk-body">Follow the links under sub headings below to view examples of the components.</p>
       {% for componentName in componentsDirectory | sort %}
         <h3 class="govuk-heading-s">{{ componentName | replace("-", " ") | capitalize }}</h3>
-        <p class="govuk-body"><a href="/components/{{ componentName }}">View the readme</a>, or browse the examples:</p>
+        <p class="govuk-body"><a class="govuk-link" href="/components/{{ componentName }}">View the readme</a>, or browse the examples:</p>
         <ul class="govuk-list govuk-list--bullet">
           {% for exampleName in componentName | componentExamples %}
             <li><a href="/components/{{ componentName }}/{{ exampleName }}/preview" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }} example</a></li>


### PR DESCRIPTION
Adding missing `govuk-link` style to the "View the readme" on the app index page.

Preview on Firefox 131.0.3 (macOS)

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/4a6712cc-79e3-4edd-b96b-234cdaf5dffc) | ![image](https://github.com/user-attachments/assets/8d23ac77-592a-43ca-9988-9b3549b254cc) |
| ![image](https://github.com/user-attachments/assets/d7fcaa22-784a-4c35-8684-ae9453e9d8ec) | ![image](https://github.com/user-attachments/assets/6342ea59-f62c-41d9-9ea9-d6f642cd62bd) | 