### PR TITLE
PLATUI-3473: expand aria-live region in timeout-dialog

### DIFF
--- a/src/components/timeout-dialog/timeout-dialog.js
+++ b/src/components/timeout-dialog/timeout-dialog.js
@@ -142,7 +142,7 @@ function TimeoutDialog($module, $sessionActivityService) {
   };
 
   const setupDialog = (signoutTime) => {
-    const $element = utils.generateDomElementFromString('<div>');
+    const $element = utils.generateDomElementFromString('<div aria-live="assertive">');
 
     if (settings.title) {
       const $tmp = utils.generateDomElementFromStringAndAppendText(
@@ -156,7 +156,7 @@ function TimeoutDialog($module, $sessionActivityService) {
       '<span id="hmrc-timeout-countdown" class="hmrc-timeout-dialog__countdown">',
     );
 
-    const $audibleMessage = utils.generateDomElementFromString('<p id="hmrc-timeout-message" class="govuk-visually-hidden screenreader-content" aria-live="assertive">');
+    const $audibleMessage = utils.generateDomElementFromString('<p id="hmrc-timeout-message" class="govuk-visually-hidden screenreader-content">');
     const $visualMessge = utils.generateDomElementFromStringAndAppendText(
       '<p class="govuk-body hmrc-timeout-dialog__message" aria-hidden="true">',
       settings.message,


### PR DESCRIPTION
# Ensure screen readers don't skip heading in timeout dialog when it opens

**Bug fix**

Took a while to get here, and we ended up with what we tried first I think but for some reason the first time it didn't work but now it does, not sure what was different

All we needed to do was expand aria-live region, and only elements that are updated are re-announced, not the whole thing

Subject to needing to test this with JAWS and NVDA

So far tested with VoiceOver on IOS and mac

Fixes #387 

## Checklist

* [ ] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [ ] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [ ] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [ ] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [ ] I've updated the [CHANGELOG](../CHANGELOG.md)
