### PR TITLE
PLATUI-3484 add delay to account-menu visual regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.58.0] - 2025-02-07
+
+### Changed
+
+- Add delay for flakey account-menu visual regression test
+
 ## [6.57.0] - 2025-02-07
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.57.0",
+  "version": "6.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.57.0",
+      "version": "6.58.0",
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.57.0",
+  "version": "6.58.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/account-header/account-header.yaml
+++ b/src/components/account-header/account-header.yaml
@@ -87,6 +87,7 @@ examples:
       classes: 'the-header-classes'
   visualRegressionTests:
     backstopScenarioOptions:
+      delay: 2000
       misMatchThreshold: 0.1
       viewports:
         - label: tablet


### PR DESCRIPTION
# Add delay to account-menu visual regression test

**Bug fix**

One visual regression test under the account-menu component has been a bit flakey as to whether or not it'll succeed. This is due to a small timing problem with it opening the menu - A small delay has been added to address this.

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
