### PR TITLE
PLATUI-3547: Incremented version of govuk-fronted to 5.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.60.0] - 2025-03-06
+
+### Changed
+
+- Updated govuk-frontend to v5.9.0
+
 ## [6.59.0] - 2025-02-11
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.59.0",
+  "version": "6.60.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.59.0",
+      "version": "6.60.0",
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",
-        "govuk-frontend": "^5.8.0"
+        "govuk-frontend": "^5.9.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
@@ -9678,9 +9678,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.8.0.tgz",
-      "integrity": "sha512-6l3f/YhDUCWjpmSW3CL95Hg8B+ZLzTf2WYo25ZtCs2Lb8UIzxxxFI8LxG7Ey/z04UuPhUunqFhTwSkQyJ69XbQ==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
+      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.59.0",
+  "version": "6.60.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/hmrc/hmrc-frontend#readme",
   "dependencies": {
     "accessible-autocomplete": "^3.0.1",
-    "govuk-frontend": "^5.8.0"
+    "govuk-frontend": "^5.9.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",

--- a/src/govuk-prototype-kit.config.json
+++ b/src/govuk-prototype-kit.config.json
@@ -10,7 +10,7 @@
   "pluginDependencies": [
     {
       "packageName": "govuk-frontend",
-      "minVersion": "5.8.0"
+      "minVersion": "5.9.0"
     }
   ],
   "assets": [


### PR DESCRIPTION
# Uplift version of govuk-frontend to v5.9.0

**New feature** 

Updated to latest version of `govuk-frontend`:
https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0

## Checklist

* [X] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [X] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [X] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
