### PR TITLE
PLATUI-2019 allow trailing/leading whitespace in accessible-autocomplete inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.63.0] - 2025-03-20
+
+### Changed
+
+- Allow trailing/leading whitespaces in accessible-autocomplete input fields
+
 ## [6.62.0] - 2025-03-19
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.62.0",
+  "version": "6.63.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.62.0",
+      "version": "6.63.0",
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.62.0",
+  "version": "6.63.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/accessible-autocomplete/accessible-autocomplete.js
+++ b/src/components/accessible-autocomplete/accessible-autocomplete.js
@@ -6,6 +6,12 @@ function AccessibleAutoComplete($module, window, document) {
 
 AccessibleAutoComplete.prototype.init = function init() {
   if (this.$module) {
+    const trimQuery = (values) => (query, syncResults) => {
+      const matches = values.filter((r) => r.toLowerCase()
+        .indexOf(query.toLowerCase().trim()) !== -1);
+      syncResults(matches.filter((item) => (item)));
+    };
+
     const selectElement = this.$module;
     const selectOptions = Array.from(selectElement.options);
     const autocompleteId = selectElement.id;
@@ -20,6 +26,7 @@ AccessibleAutoComplete.prototype.init = function init() {
       autoselect,
       defaultValue,
       minLength,
+      source: trimQuery(Array.from(this.$module.options).map((a) => a.innerText)),
       onConfirm: (chosenOption) => {
         selectElement.value = '';
         const chosenOptionOrCurrentValue = (typeof chosenOption !== 'undefined')
@@ -60,7 +67,7 @@ AccessibleAutoComplete.prototype.init = function init() {
     );
     if (autocompleteElementMissingAriaDescribedAttrs) {
       // if there is a hint and/or error then the autocomplete element
-      // needs to be aria-describedby these, which it isn't be default.
+      // needs to be aria-describedby these, which it isn't by default.
       // we need to check if it hasn't already been done to avoid adding
       // them twice if someone has added a separate patch.
       autocompleteElement.setAttribute(

--- a/src/components/accessible-autocomplete/accessible-autocomplete.yaml
+++ b/src/components/accessible-autocomplete/accessible-autocomplete.yaml
@@ -26,6 +26,7 @@ examples:
     data:
       label:
         text: Select country
+      describedBy: location-picker
       id: location-picker
       select: |
         <select id="location-picker" data-show-all-values="false" data-auto-select="false" data-default-value="" data-module="hmrc-accessible-autocomplete">
@@ -38,6 +39,7 @@ examples:
     data:
       label:
         text: Select country
+      describedBy: location-picker
       id: location-picker
       select: |
         <select id="location-picker" data-module="hmrc-accessible-autocomplete">
@@ -50,6 +52,7 @@ examples:
     data:
       label:
         text: Select country
+      describedBy: location-picker
       id: location-picker
       select: |
         <select id="location-picker" data-show-all-values="false" data-auto-select="false" data-default-value="Germany" data-module="hmrc-accessible-autocomplete">
@@ -63,6 +66,7 @@ examples:
     data:
       label:
         text: Select country
+      describedBy: location-picker
       id: location-picker
       select: |
         <select id="location-picker" data-show-all-values="false" data-auto-select="false" data-default-value="" data-module="hmrc-accessible-autocomplete">
@@ -76,6 +80,7 @@ examples:
     data:
       label:
         text: Select country
+      describedBy: location-picker
       id: location-picker
       select: |
         <select id="location-picker" data-show-all-values="true" data-auto-select="false" data-default-value="" data-module="hmrc-accessible-autocomplete">
@@ -95,6 +100,7 @@ examples:
     data:
       label:
         text: Select country
+      describedBy: location-picker
       id: location-picker
       select: |
         <select id="location-picker" data-show-all-values="false" data-auto-select="true" data-default-value="" data-module="hmrc-accessible-autocomplete">
@@ -115,6 +121,7 @@ examples:
         text: Select country
       hint:
         text: "Please select a country"
+      describedBy: location-picker
       id: location-picker
       select: |
         <select id="location-picker" data-show-all-values="false" data-auto-select="false" data-default-value="" data-module="hmrc-accessible-autocomplete">
@@ -130,6 +137,7 @@ examples:
       hint:
         text: "Please select a country"
       errorMessage: "An error occurred"
+      describedBy: location-picker
       id: location-picker
       select: |
         <select class="govuk-select govuk-select--error" aria-describedby="location-picker-error location-picker-hint" id="location-picker" data-show-all-values="false" data-auto-select="false" data-default-value="" data-module="hmrc-accessible-autocomplete">
@@ -142,6 +150,7 @@ examples:
     data:
       label:
         text: Dewiswch wlad
+      describedBy: location-picker
       id: location-picker
       select: |
         <select id="location-picker" data-language="cy" data-show-all-values="true" data-auto-select="false" data-default-value="" data-module="hmrc-accessible-autocomplete">
@@ -155,6 +164,7 @@ examples:
     data:
       label:
         text: Dewiswch wlad
+      describedBy: location-picker
       id: location-picker
       select: |
         <select id="location-picker" data-language="cy" data-min-length="3" data-show-all-values="false" data-auto-select="false" data-default-value="" data-module="hmrc-accessible-autocomplete">
@@ -168,6 +178,7 @@ examples:
     data:
       label:
         text: Dewiswch wlad
+      describedBy: location-picker
       id: location-picker
       select: |
         <select id="location-picker" data-language="cy" data-show-all-values="false" data-auto-select="true" data-default-value="" data-module="hmrc-accessible-autocomplete">

--- a/src/components/accessible-autocomplete/browser.test.js
+++ b/src/components/accessible-autocomplete/browser.test.js
@@ -113,6 +113,27 @@ describe('enhanceSelectElement on the select element provided', () => {
     expect(hintValue).toEqual('France');
   });
 
+  it('should allow trailing and leading whitespace in query', async () => {
+    await page.goto(examplePreview('accessible-autocomplete/with-show-all-values'));
+
+    const input = await page.$('#location-picker');
+    await input.click();
+
+    await input.type(' Fr ');
+    await input.click();
+
+    const autocompleteFocused = await page.$('.autocomplete__menu--visible');
+    const visibleElements = await page.evaluate(() => document.querySelectorAll('.autocomplete__option'));
+
+    expect(autocompleteFocused).toBeTruthy();
+    expect(Object.keys(visibleElements).length).toEqual(1);
+
+    await page.keyboard.press('Enter');
+    const selectedOption = await page.evaluate(() => document.querySelector('.autocomplete__option').textContent);
+
+    expect(selectedOption).toBe('France');
+  });
+
   it('should not highlight first found option when autoselect is false', async () => {
     await page.goto(examplePreview('accessible-autocomplete/default'));
 


### PR DESCRIPTION
# Allow trailing/leading whitespace in accessible-autocomplete inputs

**Bug fix** (delete as appropriate)

- Added a source function to trim whitespace on queries

Fixes # https://github.com/hmrc/accessibility-audits-external/issues/2193 

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
