### PR TITLE
PLATUI-3595 timeout with viewport width set

### DIFF
--- a/src/components/timeout-dialog/_timeout-dialog.scss
+++ b/src/components/timeout-dialog/_timeout-dialog.scss
@@ -27,8 +27,9 @@ html {
   z-index: 1002;
   top: 50%;
   left: 50%;
-  width: 280px;
-  padding: 30px;
+  width: 35vw;
+  height: 30vh;
+  padding: 1.618vw;
   overflow-x: hidden;
   overflow-y: auto;
   transform: translate(-50%, -50%);
@@ -36,7 +37,8 @@ html {
   background-color: govuk-colour("white");
 
   @include govuk-media-query($from: tablet) {
-    width: 435px;
+    width: 25vw;
+    height: 20vh;
   }
 
   &:focus {


### PR DESCRIPTION
# Timeout with viewport width set

**This is a WIP, do not merge.**

**Bug fix** 

When on a small screen and zoomed in, elements are unable to be navigated through correctly, due to the lack of scroll bars.

## Checklist

* [ ] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [ ] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [ ] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [ ] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [ ] I've updated the [CHANGELOG](../CHANGELOG.md)
