### PR TITLE
PLATUI-3595 full screen modal on small screens

### DIFF
--- a/src/components/timeout-dialog/_timeout-dialog.scss
+++ b/src/components/timeout-dialog/_timeout-dialog.scss
@@ -16,12 +16,6 @@
   -moz-opacity: 0.8;
 }
 
-html {
-  &.no-scroll {
-    overflow: hidden;
-  }
-}
-
 .hmrc-timeout-dialog {
   position: fixed;
   z-index: 1002;
@@ -29,14 +23,22 @@ html {
   left: 50%;
   width: 280px;
   padding: 30px;
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: auto;
   transform: translate(-50%, -50%);
   border: 5px solid govuk-colour("black");
   background-color: govuk-colour("white");
 
   @include govuk-media-query($from: tablet) {
     width: 435px;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    width: 100vw;
+    height: 100vh;
+    border-radius: 0;
+    display: grid;
+    place-items: center;
+    padding: 5px;
   }
 
   &:focus {


### PR DESCRIPTION
# Full Screen Modal on Small Screens

**This is a WIP, do not merge.**

**Bug fix**

When on a small screen and zoomed in, elements are unable to be navigated through correctly, due to the lack of scroll bars.

## Checklist

* [ ] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [ ] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [ ] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [ ] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [ ] I've updated the [CHANGELOG](../CHANGELOG.md)
