### PR TITLE
PLATUI-3595 set max-width to timeout dialog

### DIFF
--- a/src/components/timeout-dialog/_timeout-dialog.scss
+++ b/src/components/timeout-dialog/_timeout-dialog.scss
@@ -16,27 +16,20 @@
   -moz-opacity: 0.8;
 }
 
-html {
-  &.no-scroll {
-    overflow: hidden;
-  }
-}
-
 .hmrc-timeout-dialog {
   position: fixed;
   z-index: 1002;
   top: 50%;
   left: 50%;
-  width: 280px;
+  max-width: 280px;
   padding: 30px;
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: auto;
   transform: translate(-50%, -50%);
   border: 5px solid govuk-colour("black");
   background-color: govuk-colour("white");
 
   @include govuk-media-query($from: tablet) {
-    width: 435px;
+    max-width: 435px;
   }
 
   &:focus {


### PR DESCRIPTION
# Timeout with max-width set

**This is a WIP, do not merge.**

**Bug fix** 

When on a small screen and zoomed in, elements are unable to be navigated through correctly, due to the lack of scroll bars.

## Checklist

* [ ] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [ ] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [ ] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [ ] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [ ] I've updated the [CHANGELOG](../CHANGELOG.md)
