### PR TITLE
PLATUI-3788 try-catch on initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.73.0] - 2025-06-23
+
+### Changed
+
+- Wrap components that need initialising in a try-catch, so if one component errors, the others can continue to function
+
 ## [6.72.0] - 2025-06-20
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.72.0",
+  "version": "6.73.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.72.0",
+      "version": "6.73.0",
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.72.0",
+  "version": "6.73.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/all.js
+++ b/src/all.js
@@ -6,13 +6,17 @@ import SessionActivityService from './components/timeout-dialog/session-activity
 import HmrcPrintLink from './components/hmrc-print-link/hmrc-print-link';
 
 function initAll() {
+  function initError(componentName, message) {
+    // eslint-disable-next-line no-console
+    return console.error(`hmrc-frontend - ${componentName} failed to initialise: ${message}`);
+  }
+
   const $AccountMenuSelector = '[data-module="hmrc-account-menu"]';
   if (document.querySelector($AccountMenuSelector)) {
     try {
       new AccountMenu($AccountMenuSelector).init();
     } catch ({ message }) {
-      // eslint-disable-next-line no-console
-      console.error(`hmrc-frontend - AccountMenu failed to initialise: ${message}`);
+      initError('AccountMenu', message);
     }
   }
 
@@ -21,8 +25,7 @@ function initAll() {
     try {
       new HmrcPrintLink($HmrcPrintLink, window).init();
     } catch ({ message }) {
-      // eslint-disable-next-line no-console
-      console.error(`hmrc-frontend - HmrcPrintLinks failed to initialise: ${message}`);
+      initError('HmrcPrintLink', message);
     }
   });
 
@@ -34,8 +37,7 @@ function initAll() {
     try {
       new TimeoutDialog($TimeoutDialog, sessionActivityService).init();
     } catch ({ message }) {
-      // eslint-disable-next-line no-console
-      console.error(`hmrc-frontend - TimeoutDialog failed to initialise: ${message}`);
+      initError('TimeoutDialog', message);
     }
   }
 
@@ -44,8 +46,7 @@ function initAll() {
     try {
       new UserResearchBanner($UserResearchBanner).init();
     } catch ({ message }) {
-      // eslint-disable-next-line no-console
-      console.error(`hmrc-frontend - UserResearchBanner failed to initialise: ${message}`);
+      initError('UserResearchBanner', message);
     }
   }
 
@@ -55,7 +56,7 @@ function initAll() {
       new BackLinkHelper($BackLink, window, document).init();
     } catch ({ message }) {
       // eslint-disable-next-line no-console
-      console.error(`hmrc-frontend - BackLinkHelper failed to initialise: ${message}`);
+      initError('BackLinkHelper', message);
     }
   });
 }

--- a/src/all.js
+++ b/src/all.js
@@ -6,27 +6,28 @@ import SessionActivityService from './components/timeout-dialog/session-activity
 import HmrcPrintLink from './components/hmrc-print-link/hmrc-print-link';
 
 function initAll() {
-  function initError(componentName, message) {
-    // eslint-disable-next-line no-console
-    return console.error(`hmrc-frontend - ${componentName} failed to initialise: ${message}`);
+  function logAndIgnoreErrors(init) {
+    try {
+      init();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      return console.error('hmrc-frontend component initialisation failed', error);
+    }
+    return true;
   }
 
   const $AccountMenuSelector = '[data-module="hmrc-account-menu"]';
   if (document.querySelector($AccountMenuSelector)) {
-    try {
+    logAndIgnoreErrors(() => {
       new AccountMenu($AccountMenuSelector).init();
-    } catch ({ message }) {
-      initError('AccountMenu', message);
-    }
+    });
   }
 
   const $HmrcPrintLinks = document.querySelectorAll('a[data-module="hmrc-print-link"]');
   $HmrcPrintLinks.forEach(($HmrcPrintLink) => {
-    try {
+    logAndIgnoreErrors(() => {
       new HmrcPrintLink($HmrcPrintLink, window).init();
-    } catch ({ message }) {
-      initError('HmrcPrintLink', message);
-    }
+    });
   });
 
   const sessionActivityService = new SessionActivityService(window.BroadcastChannel);
@@ -34,30 +35,23 @@ function initAll() {
 
   const $TimeoutDialog = document.querySelector('meta[name="hmrc-timeout-dialog"]');
   if ($TimeoutDialog) {
-    try {
+    logAndIgnoreErrors(() => {
       new TimeoutDialog($TimeoutDialog, sessionActivityService).init();
-    } catch ({ message }) {
-      initError('TimeoutDialog', message);
-    }
+    });
   }
 
   const $UserResearchBanner = document.querySelector('[data-module="hmrc-user-research-banner"]');
   if ($UserResearchBanner) {
-    try {
+    logAndIgnoreErrors(() => {
       new UserResearchBanner($UserResearchBanner).init();
-    } catch ({ message }) {
-      initError('UserResearchBanner', message);
-    }
+    });
   }
 
   const $BackLinks = document.querySelectorAll('[data-module="hmrc-back-link"]');
   $BackLinks.forEach(($BackLink) => {
-    try {
+    logAndIgnoreErrors(() => {
       new BackLinkHelper($BackLink, window, document).init();
-    } catch ({ message }) {
-      // eslint-disable-next-line no-console
-      initError('BackLinkHelper', message);
-    }
+    });
   });
 }
 

--- a/src/all.js
+++ b/src/all.js
@@ -11,9 +11,8 @@ function initAll() {
       init();
     } catch (error) {
       // eslint-disable-next-line no-console
-      return console.error('hmrc-frontend component initialisation failed', error);
+      console.error('hmrc-frontend component initialisation failed', error);
     }
-    return true;
   }
 
   const $AccountMenuSelector = '[data-module="hmrc-account-menu"]';

--- a/src/all.js
+++ b/src/all.js
@@ -8,12 +8,22 @@ import HmrcPrintLink from './components/hmrc-print-link/hmrc-print-link';
 function initAll() {
   const $AccountMenuSelector = '[data-module="hmrc-account-menu"]';
   if (document.querySelector($AccountMenuSelector)) {
-    new AccountMenu($AccountMenuSelector).init();
+    try {
+      new AccountMenu($AccountMenuSelector).init();
+    } catch ({ message }) {
+      // eslint-disable-next-line no-console
+      console.error(`hmrc-frontend - AccountMenu failed to initialise: ${message}`);
+    }
   }
 
   const $HmrcPrintLinks = document.querySelectorAll('a[data-module="hmrc-print-link"]');
   $HmrcPrintLinks.forEach(($HmrcPrintLink) => {
-    new HmrcPrintLink($HmrcPrintLink, window).init();
+    try {
+      new HmrcPrintLink($HmrcPrintLink, window).init();
+    } catch ({ message }) {
+      // eslint-disable-next-line no-console
+      console.error(`hmrc-frontend - HmrcPrintLinks failed to initialise: ${message}`);
+    }
   });
 
   const sessionActivityService = new SessionActivityService(window.BroadcastChannel);
@@ -21,17 +31,32 @@ function initAll() {
 
   const $TimeoutDialog = document.querySelector('meta[name="hmrc-timeout-dialog"]');
   if ($TimeoutDialog) {
-    new TimeoutDialog($TimeoutDialog, sessionActivityService).init();
+    try {
+      new TimeoutDialog($TimeoutDialog, sessionActivityService).init();
+    } catch ({ message }) {
+      // eslint-disable-next-line no-console
+      console.error(`hmrc-frontend - TimeoutDialog failed to initialise: ${message}`);
+    }
   }
 
   const $UserResearchBanner = document.querySelector('[data-module="hmrc-user-research-banner"]');
   if ($UserResearchBanner) {
-    new UserResearchBanner($UserResearchBanner).init();
+    try {
+      new UserResearchBanner($UserResearchBanner).init();
+    } catch ({ message }) {
+      // eslint-disable-next-line no-console
+      console.error(`hmrc-frontend - UserResearchBanner failed to initialise: ${message}`);
+    }
   }
 
   const $BackLinks = document.querySelectorAll('[data-module="hmrc-back-link"]');
   $BackLinks.forEach(($BackLink) => {
-    new BackLinkHelper($BackLink, window, document).init();
+    try {
+      new BackLinkHelper($BackLink, window, document).init();
+    } catch ({ message }) {
+      // eslint-disable-next-line no-console
+      console.error(`hmrc-frontend - BackLinkHelper failed to initialise: ${message}`);
+    }
   });
 }
 

--- a/src/all.jsdom.test.js
+++ b/src/all.jsdom.test.js
@@ -35,17 +35,9 @@ describe('Init All', () => {
 
     it('should initialise correctly configured elements found on the page', () => {
       addBackLinkToPage();
-      const brokenTimeoutDialog = document.createElement('div');
-      brokenTimeoutDialog.innerHTML = `
-          <meta name="hmrc-timeout-dialog"
-            content="hmrc-timeout-dialog"
-            data-timeout="60"
-            data-countdown="55"
-            data-keep-alive-url="?keepalive"
-            data-sign-out-url=""
-            data-synchronise-tabs="true"/>
-        `; // broken configuration of timeout-dialog will error
-      document.body.appendChild(brokenTimeoutDialog.firstChild);
+      const brokenTimeoutDialog = document.createElement('meta');
+      brokenTimeoutDialog.setAttribute('content', 'hmrc-timeout-dialog'); // broken configuration of timeout-dialog will error
+      document.head.appendChild(brokenTimeoutDialog);
       HMRCFrontend.initAll();
       expect(BackLinkHelper.prototype.init).toHaveBeenCalled();
     });

--- a/src/all.jsdom.test.js
+++ b/src/all.jsdom.test.js
@@ -34,12 +34,21 @@ describe('Init All', () => {
     });
 
     it('should initialise correctly configured elements found on the page', () => {
+      const logSpy = jest.spyOn(global.console, 'error');
       addBackLinkToPage();
       const brokenTimeoutDialog = document.createElement('meta');
-      brokenTimeoutDialog.setAttribute('content', 'hmrc-timeout-dialog'); // broken configuration of timeout-dialog will error
+      brokenTimeoutDialog.setAttribute('name', 'hmrc-timeout-dialog');
+      brokenTimeoutDialog.setAttribute('content', 'hmrc-timeout-dialog');
+      brokenTimeoutDialog.setAttribute('data-timeout', '60');
+      brokenTimeoutDialog.setAttribute('data-countdown', '55');
+      brokenTimeoutDialog.setAttribute('data-keep-alive-url', '?keepalive');
+      brokenTimeoutDialog.setAttribute('data-sign-out-url', ''); // broken configuration of timeout-dialog will error
+      brokenTimeoutDialog.setAttribute('data-synchronise-tabs', 'true');
       document.head.appendChild(brokenTimeoutDialog);
       HMRCFrontend.initAll();
       expect(BackLinkHelper.prototype.init).toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith('hmrc-frontend component initialisation failed', Error('Missing config item(s): [data-sign-out-url]'));
     });
   });
 });

--- a/src/all.jsdom.test.js
+++ b/src/all.jsdom.test.js
@@ -32,5 +32,22 @@ describe('Init All', () => {
       HMRCFrontend.initAll();
       expect(BackLinkHelper.prototype.init).toHaveBeenCalledTimes(2);
     });
+
+    it('should initialise correctly configured elements found on the page', () => {
+      addBackLinkToPage();
+      const brokenTimeoutDialog = document.createElement('div');
+      brokenTimeoutDialog.innerHTML = `
+          <meta name="hmrc-timeout-dialog"
+            content="hmrc-timeout-dialog"
+            data-timeout="60"
+            data-countdown="55"
+            data-keep-alive-url="?keepalive"
+            data-sign-out-url=""
+            data-synchronise-tabs="true"/>
+        `; // broken configuration of timeout-dialog will error
+      document.body.appendChild(brokenTimeoutDialog.firstChild);
+      HMRCFrontend.initAll();
+      expect(BackLinkHelper.prototype.init).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/account-header/account-header.yaml
+++ b/src/components/account-header/account-header.yaml
@@ -142,6 +142,7 @@ examples:
       classes: 'the-header-classes'
   visualRegressionTests:
     backstopScenarioOptions:
+      delay: 2000
       viewports:
         - label: phone
           width: 320
@@ -199,6 +200,7 @@ examples:
       classes: 'the-header-classes'
   visualRegressionTests:
     backstopScenarioOptions:
+      delay: 2000
       viewports:
         - label: phone
           width: 320


### PR DESCRIPTION
# Try-Catch on Component Initialisation

**Bug fix**

When we initialise a component, if one fails, but there are multiple components that should be initialised on the same page, then they all silently don't get initialised. This ensures that if one component fails, we log it to console, but we allow the rest of the components to initialise.

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
