### PR TITLE
PLATUI-3856 add postinstall scripts to gulp package.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Adds the compatibility check to gulp required scripts
+- Adds required postinstall script to run the check for govuk-frontend compatibility on install in a prototype
 
 ## [6.79.0] - 2025-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.80.0] - 2025-08-07
+
+### Changed
+
+- Adds the compatibility check to gulp required scripts
+
 ## [6.79.0] - 2025-08-06
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.79.0",
+  "version": "6.80.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.79.0",
+      "version": "6.80.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.79.0",
+  "version": "6.80.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/account-menu/_account-menu.scss
+++ b/src/components/account-menu/_account-menu.scss
@@ -1,4 +1,15 @@
 // stylelint-disable
+// Hello friend, you may be seeing this comment when installing via govuk-prototype-kit.
+// If so, please check if your version of govuk-frontend is below 5.4.0 and if so,
+// please upgrade to a later version of govuk-frontend.
+//   - PlatUI
+// -------------------------------------------
+//         \\   ^__^ 
+//         \\  (oo)_______
+//             (__)       )\\/\\
+//                 ||----w |
+//                 ||     ||
+// - PlatMooI the PlatUI Helper Cow
 @import "../../../../govuk-frontend/dist/govuk/settings/index";
 @import "../../../../govuk-frontend/dist/govuk/tools/index";
 @import "../../../../govuk-frontend/dist/govuk/helpers/index";

--- a/src/components/account-menu/_account-menu.scss
+++ b/src/components/account-menu/_account-menu.scss
@@ -1,7 +1,6 @@
 // stylelint-disable
 // Hello friend, you may be seeing this comment when installing via govuk-prototype-kit.
-// If so, please check if your version of govuk-frontend is below 5.4.0 and if so,
-// please upgrade to a later version of govuk-frontend.
+// If so, please ensure your version of govuk-frontend is at least 5.4.0
 //   - PlatUI
 // -------------------------------------------
 //         \\   ^__^ 

--- a/tasks/gulp/package.js
+++ b/tasks/gulp/package.js
@@ -43,6 +43,7 @@ gulp.task('copy:packageJson', (done) => {
 
   const requiredScripts = [
     'preinstall',
+    'postinstall',
   ];
 
   Object.keys(packageFile.scripts).forEach((key) => {


### PR DESCRIPTION
# Add postinstall scripts to gulp package js file

**Bug fix** 

Adds the postinstall scripts for compatibility checks to the gulp required scripts

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
