### PR TITLE
PLATUI-3856 updates compatibility check to allow suppression via npmrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.81.0] - 2025-08-07
+
+### Changed
+
+- Updates compatibility check script to allow HMRC_FRONTEND_DISABLE_COMPATIBILITY_CHECK=true to be included in an npmrc file to suppress the check
+
 ## [6.80.0] - 2025-08-07
 
 ### Changed

--- a/check-compatibility-with-govuk-frontend-version.js
+++ b/check-compatibility-with-govuk-frontend-version.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const path = require('path');
 
 function hmrcFrontendDisableCompatibilityCheck() {
-  return process.env.HMRC_FRONTEND_DISABLE_COMPATIBILITY_CHECK === 'true';
+  return (process.env.npm_config_hmrc_frontend_disable_compatibility_check || process.env.HMRC_FRONTEND_DISABLE_COMPATIBILITY_CHECK) === 'true';
 }
 
 function semverGreaterThanOrEqualTo(a, b) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.80.0",
+  "version": "6.81.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.80.0",
+      "version": "6.81.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.80.0",
+  "version": "6.81.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/account-menu/_account-menu.scss
+++ b/src/components/account-menu/_account-menu.scss
@@ -1,14 +1,7 @@
 // stylelint-disable
-// Hello friend, you may be seeing this comment when installing via govuk-prototype-kit.
+// Hello friend, you may see this comment when installing via govuk-prototype-kit.
 // If so, please ensure your version of govuk-frontend is at least 5.4.0
 //   - PlatUI
-// -------------------------------------------
-//         \\   ^__^ 
-//         \\  (oo)_______
-//             (__)       )\\/\\
-//                 ||----w |
-//                 ||     ||
-// - PlatMooI the PlatUI Helper Cow
 @import "../../../../govuk-frontend/dist/govuk/settings/index";
 @import "../../../../govuk-frontend/dist/govuk/tools/index";
 @import "../../../../govuk-frontend/dist/govuk/helpers/index";

--- a/tasks/gulp/__tests__/check-compatibility-with-govuk-frontend-version.test.js
+++ b/tasks/gulp/__tests__/check-compatibility-with-govuk-frontend-version.test.js
@@ -173,5 +173,46 @@ describe('govuk-frontend version compatibility check', () => {
         });
       });
     });
+    describe('when \'npm_config_hmrc_frontend_disable_compatibility_check\' is set', () => {
+      it('should exit the process with code 0 when set to true', (done) => {
+        createMockPackage({
+          dependencies: {
+            'govuk-prototype-kit': '13.0.0',
+            'govuk-frontend': '4.4.0',
+            'hmrc-frontend': '6.79.0',
+          },
+        });
+        runCompatibilityCheck({
+          npm_config_hmrc_frontend_disable_compatibility_check: 'true',
+        }).on('exit', (code) => {
+          try {
+            expect(code).toBe(0);
+            done();
+          } catch (error) {
+            done(error);
+          }
+        });
+      });
+
+      it('should exit the process with code 1 when set with a value other than true and incompatible version', (done) => {
+        createMockPackage({
+          dependencies: {
+            'govuk-prototype-kit': '13.0.0',
+            'govuk-frontend': '4.4.0',
+            'hmrc-frontend': '6.79.0',
+          },
+        });
+        runCompatibilityCheck({
+          npm_config_hmrc_frontend_disable_compatibility_check: 'blue',
+        }).on('exit', (code) => {
+          try {
+            expect(code).toBe(1);
+            done();
+          } catch (error) {
+            done(error);
+          }
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
# Updates compatibility check to allow suppression via npmrc

**Bug fix**

Users can now set their npmrc file to include `HMRC_FRONTEND_DISABLE_COMPATIBILITY_CHECK=true` instead of setting a local environment variable.

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
