### PR TITLE
PLATUI-3901: adding in some more explicit waits to combat vrt test flakiness

### DIFF
--- a/backstop_data/engine_scripts/puppet/beforeTakingScreenshotHelper.js
+++ b/backstop_data/engine_scripts/puppet/beforeTakingScreenshotHelper.js
@@ -4,8 +4,11 @@ module.exports = async (page, { beforeTakingScreenshot }) => {
   allowedPageActions.click = async selector =>
     await page.click(selector);
 
-  allowedPageActions.hover = async selector =>
+  allowedPageActions.hover = async selector => {
     await page.hover(selector);
+    // to try and reduce seemingly unavoidable flakiness
+    await page.waitForTimeout(100);
+  }
 
   allowedPageActions.focus = async selector =>
     await page.focus(selector);
@@ -16,8 +19,11 @@ module.exports = async (page, { beforeTakingScreenshot }) => {
   allowedPageActions.press = async key =>
     await page.press(key);
 
-  allowedPageActions.waitFor = async selector =>
-    await page.waitForSelector(selector);
+  allowedPageActions.waitFor = async selector => {
+    await page.locator(selector).waitFor();
+    // to try and reduce seemingly unavoidable flakiness
+    await page.waitForTimeout(100);
+  }
 
   allowedPageActions.setRefererSameDomain = async refererIsSameDomain => {
     if(refererIsSameDomain) {

--- a/src/components/account-header/account-header.yaml
+++ b/src/components/account-header/account-header.yaml
@@ -167,10 +167,12 @@ examples:
       account-menu-dropdown-open-messages-hovered:
         beforeTakingScreenshot:
           - click: ".hmrc-account-menu__link[aria-expanded='false']"
+          - waitFor: ".main-nav-is-open"
           - hover: ".hmrc-account-menu__link[href='/messages/href']"
       account-menu-dropdown-open-messages-focused:
         beforeTakingScreenshot:
           - click: ".hmrc-account-menu__link[aria-expanded='false']"
+          - waitFor: ".main-nav-is-open"
           - focus: ".hmrc-account-menu__link[href='/messages/href']"
 
 - name: link-states-on-mobile-with-dropdown-link-active
@@ -212,13 +214,16 @@ examples:
       account-menu-dropdown-open:
         beforeTakingScreenshot:
           - click: ".hmrc-account-menu__link[aria-expanded='false']"
+          - waitFor: ".main-nav-is-open"
       account-menu-dropdown-open-active-link-hovered:
         beforeTakingScreenshot:
           - click: ".hmrc-account-menu__link[aria-expanded='false']"
+          - waitFor: ".main-nav-is-open"
           - hover: ".hmrc-account-menu__link[href='/messages/href']"
       account-menu-dropdown-open-active-link-focused:
         beforeTakingScreenshot:
           - click: ".hmrc-account-menu__link[aria-expanded='false']"
+          - waitFor: ".main-nav-is-open"
           - focus: ".hmrc-account-menu__link[href='/messages/href']"
 
 - name: all-available-options-with-tudor-crown


### PR DESCRIPTION
haven't really been able to find a way to put my finger on the scale such that the flakiness we're experiencing becomes more reproducible so opting instead to just add in some explicit timeouts after actions we're experiencing flakiness with in a bit of a brute force attempt. I have omitted npm version bump to avoid a release with no functional changes.