### PR TITLE
NOJIRA add assets/images to dist via gulp task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.86.0] - 2025-08-19
+
+### Changed
+
+- Ensures that the crest image files are added to dist via gulp tasks, making them accessible via s3
+
 ## [6.85.0] - 2025-08-18
 
 ### Changed

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,7 @@ const { publishLocalWebjar, buildWebjar } = require('./tasks/gulp/webjar');
 
 const copyDistFiles = series(
   'copy-hmrc-images',
-  'copy-govuk-crest-images',
+  'copy-hmrc-assets',
   'copy-govuk-images',
   'copy-govuk-fonts',
   'copy-govuk-manifest-json',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@ const { publishLocalWebjar, buildWebjar } = require('./tasks/gulp/webjar');
 
 const copyDistFiles = series(
   'copy-hmrc-images',
+  'copy-govuk-crest-images',
   'copy-govuk-images',
   'copy-govuk-fonts',
   'copy-govuk-manifest-json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.85.0",
+  "version": "6.86.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.85.0",
+      "version": "6.86.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.85.0",
+  "version": "6.86.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/tasks/gulp/dist.js
+++ b/tasks/gulp/dist.js
@@ -6,7 +6,7 @@ gulp.task('copy-hmrc-images', () => gulp.src([
 ], { cwd: `${configPaths.src}`, encoding: false })
   .pipe(gulp.dest(`${configPaths.dist}/components`)));
 
-gulp.task('copy-govuk-crest-images', () => gulp.src([
+gulp.task('copy-hmrc-assets', () => gulp.src([
   'assets/images/*',
 ], { cwd: `${configPaths.src}`, encoding: false })
   .pipe(gulp.dest(`${configPaths.dist}/assets/images`)));

--- a/tasks/gulp/dist.js
+++ b/tasks/gulp/dist.js
@@ -5,3 +5,8 @@ gulp.task('copy-hmrc-images', () => gulp.src([
   'components/*/images/*',
 ], { cwd: `${configPaths.src}`, encoding: false })
   .pipe(gulp.dest(`${configPaths.dist}/components`)));
+
+gulp.task('copy-govuk-crest-images', () => gulp.src([
+  'assets/images/*',
+], { cwd: `${configPaths.src}`, encoding: false })
+  .pipe(gulp.dest(`${configPaths.dist}/assets/images`)));


### PR DESCRIPTION
# Add `assets/images/` to `dist/` via gulp task

**Bug fix**

This builds the `assets/images/` directory to `dist/`, allowing upload to s3

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
