### PR TITLE
PLATUI-3933 bump govuk-frontend to 5.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.88.0] - 2025-09-01
+
+### Changed
+
+- Bumped govuk-frontend to 5.11.2
+
 ## [6.87.0] - 2025-08-21
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.87.0",
+  "version": "6.88.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.87.0",
+      "version": "6.88.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",
-        "govuk-frontend": "^5.11.1"
+        "govuk-frontend": "^5.11.2"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
@@ -9433,9 +9433,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.1.tgz",
-      "integrity": "sha512-hJJFpaer4MZLvz/2F9RZ7xZ6FqlzpxL9aw6YWOGK3F1tn419xj2WcVXwOC8Bcj/dc/LanknbWJDGkb+IdkuhTQ==",
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.2.tgz",
+      "integrity": "sha512-eHV8EMxYNjc+omFhB0HktQ3QmA3ZRdDsgRDlUIik+TpUHerR3XKXpo4zh/OGO2/C2mz65cX0XT0k4QrRFJZU8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.87.0",
+  "version": "6.88.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",
@@ -45,7 +45,7 @@
   "homepage": "https://github.com/hmrc/hmrc-frontend#readme",
   "dependencies": {
     "accessible-autocomplete": "^3.0.1",
-    "govuk-frontend": "^5.11.1"
+    "govuk-frontend": "^5.11.2"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",

--- a/src/govuk-prototype-kit.config.json
+++ b/src/govuk-prototype-kit.config.json
@@ -10,7 +10,7 @@
   "pluginDependencies": [
     {
       "packageName": "govuk-frontend",
-      "minVersion": "5.11.1"
+      "minVersion": "5.11.2"
     }
   ],
   "assets": [


### PR DESCRIPTION
# Bump govuk-frontend to 5.11.2

**Dependency upgrade**

- Bump govuk-frontend to 5.11.2
  - These are minor changes

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
