### PR TITLE
PLATUI-3922: Updated gulp task to include rebranded images in dist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.89.0] - 2025-09-10
+
+### Changed
+
+- Added rebranded images and manifest to `dist`
+
 ## [6.88.0] - 2025-09-01
 
 ### Changed

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,8 +18,10 @@ const copyDistFiles = series(
   'copy-hmrc-images',
   'copy-hmrc-assets',
   'copy-govuk-images',
+  'copy-govuk-images-rebrand',
   'copy-govuk-fonts',
   'copy-govuk-manifest-json',
+  'copy-govuk-manifest-json-rebrand',
 );
 
 const copyPackageFiles = series(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.88.0",
+  "version": "6.89.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.88.0",
+      "version": "6.89.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.88.0",
+  "version": "6.89.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",


### PR DESCRIPTION
# Updated gulp task to include rebranded images in dist

**Bug fix**

Rebranded images were not being included in the `dist`, and therefore are not available via S3. This change fixes that.

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
