### PR TITLE
PLATUI-3945 removes data-journey-click attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.93.0] - 2025-09-18
+
+### Changed
+
+- Removed unused data-journey attributes from header, language-select and service-navigation-language-select components
+
 ## [6.92.0] - 2025-09-17
 
 ### Changed
 
-- removed a template file used by our automated tests that we were incorrectly publishing to npm
+- Removed a template file used by our automated tests that we were incorrectly publishing to npm
 
 ## [6.91.0] - 2025-09-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Removed unused data-journey attributes from header, language-select and service-navigation-language-select components
+- Removed unused data-journey-click attributes from header, language-select and service-navigation-language-select components
 
 ## [6.92.0] - 2025-09-17
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.92.0",
+  "version": "6.93.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.92.0",
+      "version": "6.93.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.92.0",
+  "version": "6.93.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/header/header.yaml
+++ b/src/components/header/header.yaml
@@ -672,7 +672,7 @@ examples:
                   <span aria-current="true">ENG</span>
                 </li>
                 <li class="hmrc-service-navigation-language-select__list-item">
-                  <a href="/components/service-navigation-language-select/welsh/preview" hreflang="cy" lang="cy" rel="alternate" class="govuk-link govuk-service-navigation__link" data-journey-click="link - click:lang-select:Cymraeg">
+                  <a href="/components/service-navigation-language-select/welsh/preview" hreflang="cy" lang="cy" rel="alternate" class="govuk-link govuk-service-navigation__link">
                     CYM<span class="govuk-visually-hidden"> – Newid yr iaith i’r Gymraeg</span>
                   </a>
                 </li>

--- a/src/components/language-select/jsdom.test.js
+++ b/src/components/language-select/jsdom.test.js
@@ -25,7 +25,6 @@ describe('Language select', () => {
       expect($component.attr('hreflang')).toEqual('cy');
       expect($component.attr('lang')).toEqual('cy');
       expect($component.attr('href')).toEqual(examples.default.cy.href);
-      expect($component.data('journeyClick')).toEqual('link - click:lang-select:Cymraeg');
 
       expect($component.find('.govuk-visually-hidden').eq(0).text()).toEqual('Newid yr iaith i’r Gymraeg');
       expect($component.find('[aria-hidden="true"]').eq(0).text()).toEqual('Cymraeg');
@@ -44,7 +43,6 @@ describe('Language select', () => {
       expect($component.attr('hreflang')).toEqual('en');
       expect($component.attr('lang')).toEqual('en');
       expect($component.attr('href')).toEqual(examples.welsh.en.href);
-      expect($component.data('journeyClick')).toEqual('link - click:lang-select:English');
 
       expect($component.find('.govuk-visually-hidden').eq(0).text()).toEqual('Change the language to English');
       expect($component.find('[aria-hidden="true"]').eq(0).text()).toEqual('English');

--- a/src/components/language-select/template.njk
+++ b/src/components/language-select/template.njk
@@ -9,8 +9,7 @@
           hreflang="cy"
           lang="cy"
           rel="alternate"
-          class="govuk-link"
-          data-journey-click="link - click:lang-select:Cymraeg">
+          class="govuk-link">
           <span class="govuk-visually-hidden">Newid yr iaith i’r Gymraeg</span>
           <span aria-hidden="true">Cymraeg</span>
         </a>
@@ -27,8 +26,7 @@
           hreflang="en"
           lang="en"
           rel="alternate"
-          class="govuk-link"
-          data-journey-click="link - click:lang-select:English">
+          class="govuk-link">
           <span class="govuk-visually-hidden">Change the language to English</span>
           <span aria-hidden="true">English</span>
         </a>

--- a/src/components/service-navigation-language-select/jsdom.test.js
+++ b/src/components/service-navigation-language-select/jsdom.test.js
@@ -25,7 +25,6 @@ describe('Service Navigation Language Select', () => {
       expect($component.attr('hreflang')).toEqual('cy');
       expect($component.attr('lang')).toEqual('cy');
       expect($component.attr('href')).toEqual(examples.default.cy.href);
-      expect($component.data('journeyClick')).toEqual('link - click:lang-select:Cymraeg');
 
       expect($component.find('.govuk-visually-hidden').eq(0).text()).toEqual(' – Newid yr iaith i’r Gymraeg');
       expect($.text().trim().replace(/[\s,\n]+/g, ' ')).toEqual('ENG CYM – Newid yr iaith i’r Gymraeg');
@@ -43,7 +42,6 @@ describe('Service Navigation Language Select', () => {
       expect($component.attr('hreflang')).toEqual('en');
       expect($component.attr('lang')).toEqual('en');
       expect($component.attr('href')).toEqual(examples.welsh.en.href);
-      expect($component.data('journeyClick')).toEqual('link - click:lang-select:English');
       expect($component.find('.govuk-visually-hidden').eq(0).text()).toEqual(' – Change the language to English');
       expect($.text().trim().replace(/[\s,\n]+/g, ' ')).toEqual('ENG – Change the language to English CYM');
 

--- a/src/components/service-navigation-language-select/template.njk
+++ b/src/components/service-navigation-language-select/template.njk
@@ -9,8 +9,7 @@
           hreflang="cy"
           lang="cy"
           rel="alternate"
-          class="govuk-link govuk-service-navigation__link"
-          data-journey-click="link - click:lang-select:Cymraeg">
+          class="govuk-link govuk-service-navigation__link">
           CYM<span class="govuk-visually-hidden"> – Newid yr iaith i’r Gymraeg</span>
         </a>
       </li>
@@ -26,8 +25,7 @@
           hreflang="en"
           lang="en"
           rel="alternate"
-          class="govuk-link govuk-service-navigation__link"
-          data-journey-click="link - click:lang-select:English">
+          class="govuk-link govuk-service-navigation__link">
           ENG<span class="govuk-visually-hidden"> – Change the language to English</span>
         </a>
       </li>


### PR DESCRIPTION
# Remove data-journey attributes

**Refactoring**

Removes the `data-journey-click` attribute from three components:
- header
- language-select
- service-navigation-language-select

This is no longer used and creates unnecessary overhead

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
