### PR TITLE
PLATUI-3968: Bumped govuk-frontend version to 5.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.94.0] - 2025-09-24
+
+### Changed
+
+- Bumped govuk-frontend to 5.12.0
+
 ## [6.93.0] - 2025-09-18
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.93.0",
+  "version": "6.94.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.93.0",
+      "version": "6.94.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",
-        "govuk-frontend": "^5.11.2"
+        "govuk-frontend": "^5.12.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
@@ -8835,10 +8835,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.2.tgz",
-      "integrity": "sha512-eHV8EMxYNjc+omFhB0HktQ3QmA3ZRdDsgRDlUIik+TpUHerR3XKXpo4zh/OGO2/C2mz65cX0XT0k4QrRFJZU8Q==",
-      "license": "MIT",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.12.0.tgz",
+      "integrity": "sha512-gNr/UVDoORVOqVKTC9i9HOKKPeM4IDTAqtnd3t6U8LQibEr+8Q+FB7Id0u/MfR/5mqPfenG/+VGLW96vJXok/g==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.93.0",
+  "version": "6.94.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/hmrc/hmrc-frontend#readme",
   "dependencies": {
     "accessible-autocomplete": "^3.0.1",
-    "govuk-frontend": "^5.11.2"
+    "govuk-frontend": "^5.12.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",

--- a/src/govuk-prototype-kit.config.json
+++ b/src/govuk-prototype-kit.config.json
@@ -10,7 +10,7 @@
   "pluginDependencies": [
     {
       "packageName": "govuk-frontend",
-      "minVersion": "5.11.2"
+      "minVersion": "5.12.0"
     }
   ],
   "assets": [


### PR DESCRIPTION
# Bumped govuk-frontend version to 5.12.0

**New feature** 

Bumped govuk-frontend version to 5.12.0

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
