### PR TITLE
PLATUI-3998 bump govuk-frontend and remove sass-mq refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.93.0] - 2025-10-14
+
+### Changed
+
+- Removed references to sass-mq and instead utilises govuk-frontend's updated sass functions
+
 ## [6.92.0] - 2025-09-17
 
 ### Changed
 
-- removed a template file used by our automated tests that we were incorrectly publishing to npm
+- Removed a template file used by our automated tests that we were incorrectly publishing to npm
 
 ## [6.91.0] - 2025-09-15
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.92.0",
+  "version": "6.93.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.92.0",
+      "version": "6.93.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",
-        "govuk-frontend": "^5.11.2"
+        "govuk-frontend": "^5.13.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
@@ -8835,9 +8835,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.2.tgz",
-      "integrity": "sha512-eHV8EMxYNjc+omFhB0HktQ3QmA3ZRdDsgRDlUIik+TpUHerR3XKXpo4zh/OGO2/C2mz65cX0XT0k4QrRFJZU8Q==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.13.0.tgz",
+      "integrity": "sha512-6N3pHelWN7wftdM6e4YEzZAfattapa1gnd+Al6d5PUbfTr9D+T2dnphpNpjX75CTEhihlQqlL0RDQ3WIfZ3PSg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
@@ -17427,9 +17427,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.92.0",
+  "version": "6.93.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/hmrc/hmrc-frontend#readme",
   "dependencies": {
     "accessible-autocomplete": "^3.0.1",
-    "govuk-frontend": "^5.11.2"
+    "govuk-frontend": "^5.13.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",

--- a/src/components/account-menu/_account-menu.scss
+++ b/src/components/account-menu/_account-menu.scss
@@ -5,7 +5,6 @@
 @import "../../../../govuk-frontend/dist/govuk/settings/index";
 @import "../../../../govuk-frontend/dist/govuk/tools/index";
 @import "../../../../govuk-frontend/dist/govuk/helpers/index";
-@import "../../../../govuk-frontend/dist/govuk/vendor/sass-mq";
 
 // previously provided by govuk-template, no equivalent in govuk-frontend
 .hidden {
@@ -359,7 +358,7 @@ $hmrc-banner-blue: #005ea5;
   }
 }
 
-@include mq(tablet) {
+@media (min-width: govuk-breakpoint-value(tablet)) {
   .hmrc-full-width-banner__close {
     right: 35px;
   }

--- a/src/components/add-to-a-list/_add-to-a-list.scss
+++ b/src/components/add-to-a-list/_add-to-a-list.scss
@@ -1,20 +1,19 @@
 @import "../../../../govuk-frontend/dist/govuk/settings/index";
 @import "../../../../govuk-frontend/dist/govuk/tools/index";
 @import "../../../../govuk-frontend/dist/govuk/helpers/index";
-@import "../../../../govuk-frontend/dist/govuk/vendor/sass-mq";
 
 .hmrc-add-to-a-list {
   padding-left: 0;
 
   @include govuk-font($size: 19);
 
-  @include mq($from: desktop) {
+  @media (min-width: govuk-breakpoint-value(desktop)) {
     display: table;
   }
 }
 
 .hmrc-add-to-a-list--short {
-  @include mq($from: desktop) {
+  @media (min-width: govuk-breakpoint-value(desktop)) {
     // to make group of q&a line up horizontally (unless there is just one group)
     width: 100%;
 
@@ -26,7 +25,7 @@
 }
 
 .hmrc-add-to-a-list--long {
-  @include mq($from: desktop) {
+  @media (min-width: govuk-breakpoint-value(desktop)) {
     // to make group of q&a line up horizontally (unless there is just one group)
     width: 100%;
 
@@ -43,7 +42,7 @@
   padding-bottom: govuk-spacing(1);
   border-bottom: 1px solid $govuk-border-colour;
 
-  @include mq($from: desktop) {
+  @media (min-width: govuk-breakpoint-value(desktop)) {
     display: table-row;
     padding-bottom: 0;
     border-bottom-width: 0;
@@ -56,7 +55,7 @@
   display: block;
   margin: 0;
 
-  @include mq($from: desktop) {
+  @media (min-width: govuk-breakpoint-value(desktop)) {
     display: table-cell;
     padding: govuk-spacing(3) 0;
     border-bottom: 1px solid $govuk-border-colour;
@@ -67,7 +66,7 @@
   margin: govuk-spacing(2) govuk-spacing(9) 0 0;
   font-weight: bold;
 
-  @include mq($from: desktop) {
+  @media (min-width: govuk-breakpoint-value(desktop)) {
     margin: 0;
   }
 }
@@ -81,7 +80,7 @@
   margin-bottom: govuk-spacing(2);
   text-align: right;
 
-  @include mq($from: desktop) {
+  @media (min-width: govuk-breakpoint-value(desktop)) {
     padding-right: 0;
   }
 }
@@ -92,7 +91,7 @@
   right: 0;
   text-align: right;
 
-  @include mq($from: desktop) {
+  @media (min-width: govuk-breakpoint-value(desktop)) {
     position: static;
 
     + .hmrc-add-to-a-list__remove {

--- a/src/components/currency-input/_currency-input.scss
+++ b/src/components/currency-input/_currency-input.scss
@@ -1,7 +1,6 @@
 @import "../../../../govuk-frontend/dist/govuk/settings/index";
 @import "../../../../govuk-frontend/dist/govuk/tools/index";
 @import "../../../../govuk-frontend/dist/govuk/helpers/index";
-@import "../../../../govuk-frontend/dist/govuk/vendor/sass-mq";
 
 .hmrc-currency-input__wrapper {
   position: relative;

--- a/src/components/timeout-dialog/_timeout-dialog.scss
+++ b/src/components/timeout-dialog/_timeout-dialog.scss
@@ -2,7 +2,6 @@
 @import "../../../../govuk-frontend/dist/govuk/settings/index";
 @import "../../../../govuk-frontend/dist/govuk/tools/index";
 @import "../../../../govuk-frontend/dist/govuk/helpers/index";
-@import "../../../../govuk-frontend/dist/govuk/vendor/sass-mq";
 
 .hmrc-timeout-overlay {
   position: fixed;

--- a/src/govuk-prototype-kit.config.json
+++ b/src/govuk-prototype-kit.config.json
@@ -10,7 +10,7 @@
   "pluginDependencies": [
     {
       "packageName": "govuk-frontend",
-      "minVersion": "5.11.2"
+      "minVersion": "5.13.0"
     }
   ],
   "assets": [


### PR DESCRIPTION
# Bump govuk-frontend version and remove sass-mq refs

**Version bump** 

- Bump govuk-frontend to latest (5.13.0)
- Remove all references to sass-mq

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
