### PR TITLE
PLATUI-4055: Add hmrc-service-navigation-language-select to styles excluded from print views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.102.0] - 2025-11-19
+
+### Changed
+
+- Added `hmrc-service-navigation-language-select` to `hmrc-frontend-print-overrides.scss` to ensure new language select 
+  is not including in print views
+
 ## [6.101.0] - 2025-11-17
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.101.0",
+  "version": "6.102.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.101.0",
+      "version": "6.102.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.101.0",
+  "version": "6.102.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/hmrc-frontend-print-overrides.scss
+++ b/src/hmrc-frontend-print-overrides.scss
@@ -5,7 +5,8 @@
   .govuk-footer__section,
   .govuk-footer__inline-list,
   .hmrc-report-technical-issue,
-  .hmrc-language-select {
+  .hmrc-language-select,
+  .hmrc-service-navigation-language-select {
     display: none !important;
   }
 }


### PR DESCRIPTION
# Add hmrc-service-navigation-language-select to styles excluded from print views

**Bug fix**

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
