### PR TITLE
PLATUI-4002: rerelease previous version as new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.105.0] - 2025-12-10
+
+### Changed
+
+- We are re-releasing 6.104.0 - because it didn't publish to npm correctly
+
 ## [6.104.0] - 2025-11-28
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.104.0",
+  "version": "6.105.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.104.0",
+      "version": "6.105.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.104.0",
+  "version": "6.105.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",


### PR DESCRIPTION
6.104.0 failed to publish to npm, easier to release again to trigger new publish than retry the publish of 6.104.0

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
