### PR TITLE
NOJIRA fix compatibility issue with govuk-frontend v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.114.0] - 2026-02-11
+
+### Changed
+
+- Removed use of _govuk-rebrand mixin to be compatible with govuk-frontend v6
+
 ## [6.113.0] - 2026-02-02
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.113.0",
+  "version": "6.114.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "6.113.0",
+      "version": "6.114.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "6.113.0",
+  "version": "6.114.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/service-navigation-language-select/_service-navigation-language-select.scss
+++ b/src/components/service-navigation-language-select/_service-navigation-language-select.scss
@@ -52,7 +52,7 @@
     margin-bottom: 0;
     padding: govuk-spacing(4) 0;
 
-    @include _govuk-rebrand {
+    .govuk-template--rebranded & {
       padding: govuk-spacing(3) 0;
 
       // some magic numbers from govuk-frontend service nav rebrand,


### PR DESCRIPTION
We spotted this a while ago (because of broken compat with older govuk frontend versions) and then forgot about it!

:facepalm: totally my fault

# stop using mixin not available in old / latest govuk-frontend

**Bug fix**

with this mixin being used we aren't compatible with older versions of govuk-frontend or now the latest release

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
