### PR TITLE
PLATUI-4277: Adding accessible-autocomplete transition delay via CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [7.14.0] - 2026-05-13
+
+### Changed
+
+- Updated the `accessible-autocomplete` patched CSS to add a small transition delay. This allows time for the drop down to close when no option selected.
+
 ## [7.13.0] - 2026-05-11
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "7.13.0",
+  "version": "7.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "7.13.0",
+      "version": "7.14.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "7.13.0",
+  "version": "7.14.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/accessible-autocomplete.scss
+++ b/src/accessible-autocomplete.scss
@@ -25,3 +25,8 @@ $govuk-include-default-font-face: false;
   z-index: 0;
   pointer-events: none;
 }
+
+.autocomplete__menu--hidden {
+  // stylelint-disable-next-line declaration-property-value-disallowed-list
+  transition: display 0s 200ms allow-discrete;
+}

--- a/src/components/accessible-autocomplete/accessible-autocomplete.browser.test.js
+++ b/src/components/accessible-autocomplete/accessible-autocomplete.browser.test.js
@@ -422,8 +422,7 @@ describe('Patched accessible autocomplete', () => {
       const { postedFormData } = await interceptNextFormPost(page);
       await expect(page).toFill('#location', 'South');
       // In the section below we need to click the "Submit" button twice due to a known
-      // issue where trying to click "Submit" when "No results found" causes it to
-      // move when they collapse and that then makes the click miss the button
+      // issue where trying to click "Submit" when "No results found"
       // https://github.com/alphagov/accessible-autocomplete/issues/48
       await page.click('button[type="submit"]');
       await page.click('button[type="submit"]');

--- a/src/components/accessible-autocomplete/accessible-autocomplete.browser.test.js
+++ b/src/components/accessible-autocomplete/accessible-autocomplete.browser.test.js
@@ -11,13 +11,10 @@ import { renderString as renderComponent } from '../../../lib/jest-helpers';
 const adamsPolyfill = readFileSync(path.join(__dirname, '__tests__', '2024-12-adams-polyfill.js.txt'), 'utf8');
 
 function withGovukSelect(params) {
-  return withHmrcStylesAndScripts(`<form method="post"><button type="submit">Submit</button>${
+  return withHmrcStylesAndScripts(`<form method="post">${
     // wrapped in form because adam's polyfill needs select to be in a form
-    // submit button precedes select because when it follows it, trying to
-    // click it when suggestions are showing causes it to move when they
-    // collapse and that then makes the click miss the button
     renderComponent('govuk/components/select', params)
-  }</form>`);
+  }<button type="submit">Submit</button></form>`);
 }
 
 function acceptFirstSuggestionFor(autocompleteSelector) {
@@ -424,6 +421,49 @@ describe('Patched accessible autocomplete', () => {
       await acceptFirstSuggestionFor('#location');
       const { postedFormData } = await interceptNextFormPost(page);
       await expect(page).toFill('#location', 'South');
+      // In the section below we need to click the "Submit" button twice due to a known
+      // issue where trying to click "Submit" when suggestions are showing causes it to
+      // move when they collapse and that then makes the click miss the button
+      // https://github.com/alphagov/accessible-autocomplete/issues/48
+      await page.click('button[type="submit"]');
+      await page.click('button[type="submit"]');
+      await expect(postedFormData).resolves.toBe(undefined);
+    });
+
+    it('should submit successfully if results found but none selected', async () => {
+      await render(page, withGovukSelect({
+        id: 'location',
+        name: 'location',
+        attributes: {
+          'data-module': 'hmrc-accessible-autocomplete',
+        },
+        label: {
+          text: 'Choose location',
+        },
+        errorMessage: {
+          text: 'You must choose a location',
+        },
+        hint: {
+          text: 'This can be different to where you went before',
+        },
+        items: [
+          {
+            value: ' ',
+            text: 'Choose location',
+          },
+          {
+            value: 'london',
+            text: 'London',
+          },
+        ],
+      }));
+
+      const element = await page.$('#location');
+      await expect(element).toBeAccessibleAutocomplete();
+      await expect(page).toFill('#location', 'Lon');
+      const { postedFormData } = await interceptNextFormPost(page);
+      // For this use case, we expect a single button click to now have enough
+      // time for the click to be registered due to delay added in PLATUI-4277
       await page.click('button[type="submit"]');
       await expect(postedFormData).resolves.toBe(undefined);
     });

--- a/src/components/accessible-autocomplete/accessible-autocomplete.browser.test.js
+++ b/src/components/accessible-autocomplete/accessible-autocomplete.browser.test.js
@@ -422,7 +422,7 @@ describe('Patched accessible autocomplete', () => {
       const { postedFormData } = await interceptNextFormPost(page);
       await expect(page).toFill('#location', 'South');
       // In the section below we need to click the "Submit" button twice due to a known
-      // issue where trying to click "Submit" when suggestions are showing causes it to
+      // issue where trying to click "Submit" when "No results found" causes it to
       // move when they collapse and that then makes the click miss the button
       // https://github.com/alphagov/accessible-autocomplete/issues/48
       await page.click('button[type="submit"]');


### PR DESCRIPTION
# Add a transition delay to `accessible-autocomplete` via CSS

**Bug fix**

This is it fix an issue where when the accessible autocomplete drop-down is not closed before another part of the page is clicked, the click isn't always registered because elements below the drop-down move when the drop-down closes.

Fixes PLATUI-4277.

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
