### PR TITLE
NOJIRA update npm audit exclusions

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -17,6 +17,8 @@
   "GHSA-rpmf-866q-6p89": "basic-ftp malicious FTP server can cause client-side DoS: devDependency only, no risk given our usage",
   "GHSA-q3j6-qgpj-74h6": "fast-uri: devDependency only, pulled in via eslint, no risk given our usage",
   "GHSA-v39h-62p7-jpjc": "fast-uri: devDependency only, pulled in via eslint, no risk given our usage",
-  "GHSA-v2v4-37r5-5v8g": "ip-address: devDependency only, no risk given our usage"
-
+  "GHSA-v2v4-37r5-5v8g": "ip-address: devDependency only, no risk given our usage",
+  "GHSA-q8mj-m7cp-5q26": "qs.stringify remotely triggerable DoS with TypeError on null/undefined entries in comma-format arrays: pulled in via devDependency, no risk given our usage",
+  "GHSA-58qx-3vcg-4xpx": "ws uninitialized memory disclosure issue: pulled in via devDependency, no risk given our usage",
+  "GHSA-jxxr-4gwj-5jf2": "brace-expansion large numeric range defeats documented `max` DoS protection: devDependency only, no risk given our usage"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [7.16.0] - 2026-05-26
+
+### Changed
+
+- Updated npm audit exclusions
+
 ## [7.15.0] - 2026-05-14
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "7.15.0",
-      "hasInstallScript": true,
+      "version": "7.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",


### PR DESCRIPTION
# Update NPM audit exclusions

**Security patch**

Updated nsprc to add new npm audit exclusions to the list.

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
