### PR TITLE
PLATUI-4336: Uplifted version of govuk-frontend to v6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [7.20.0] - 2026-06-11
+
+### Changed
+
+- Uplifted `govuk-frontend` version to v6.2.0.
+
 ## [7.19.0] - 2026-06-08
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "hmrc-frontend",
-  "version": "7.19.0",
+  "version": "7.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "7.19.0",
+      "version": "7.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",
-        "govuk-frontend": "^6.1.0"
+        "govuk-frontend": "^6.2.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
@@ -8774,9 +8774,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
-      "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.2.0.tgz",
+      "integrity": "sha512-PCRyQT+7kiV2dUz0Ku6Co+Nx4anOwJ7mAduXYbTQHK2krppBSynv9dBXtOYha/8j+LIzK7FqesTbJl9HD6ekHg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "7.19.0",
+  "version": "7.20.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",
@@ -45,7 +45,7 @@
   "homepage": "https://github.com/hmrc/hmrc-frontend#readme",
   "dependencies": {
     "accessible-autocomplete": "^3.0.1",
-    "govuk-frontend": "^6.1.0"
+    "govuk-frontend": "^6.2.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",

--- a/src/govuk-prototype-kit.config.json
+++ b/src/govuk-prototype-kit.config.json
@@ -10,7 +10,7 @@
   "pluginDependencies": [
     {
       "packageName": "govuk-frontend",
-      "minVersion": "6.1.0"
+      "minVersion": "6.2.0"
     }
   ],
   "assets": [


### PR DESCRIPTION
# Uplifted version of govuk-frontend to v6.2.0

**New feature**

Uplifted version of govuk-frontend to v6.2.0.

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
