### PR TITLE
PLATUI-4321: Removed unused GOVUK Frontend variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [7.23.0] - 2026-06-23
+
+- Removed GOV.UK Frontend variables that no longer exist
+
 ## [7.22.0] - 2026-06-22
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "7.22.0",
+  "version": "7.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "7.22.0",
+      "version": "7.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "7.22.0",
+  "version": "7.23.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/all-govuk-and-hmrc.scss
+++ b/src/all-govuk-and-hmrc.scss
@@ -1,7 +1,6 @@
 $govuk-global-styles: false;
 $hmrc-assets-path: "";
 $govuk-assets-path: "govuk/";
-$govuk-new-link-styles: true;
 
 @import "../../govuk-frontend/dist/govuk/index";
 @import "components/all";

--- a/src/all.scss
+++ b/src/all.scss
@@ -1,6 +1,4 @@
 $govuk-global-styles: true;
-$govuk-new-link-styles: true !default;
-$govuk-new-organisation-colours: true !default;
 
 /// Path to the assets directory, with trailing slash.
 ///


### PR DESCRIPTION
# Removed unused GOVUK Frontend variables

**Bug fix** (delete as appropriate)

Fixes # [issue 543](https://github.com/hmrc/hmrc-frontend/issues/543)

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
