### PR TITLE
Added underline to sign out link on hover/focus when high contrast is on in OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [7.31.0] - 2026-08-28
+
+- Added underline to signout link on hover/focus when high contrast is enabled in OS
+
 ## [7.30.0] - 2026-08-25
 
 - Run npm outdated as part of the npm audit command

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "7.30.0",
+  "version": "7.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "7.30.0",
+      "version": "7.31.0",
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "7.30.0",
+  "version": "7.31.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -41,11 +41,19 @@ $govuk-header-link-underline-thickness: 3px;
 
     &:hover::after {
       display: block;
+
+      @media (forced-colors: active) {
+        background-color: linktext;
+      }
     }
 
     &:focus::after {
       display: block;
       background-color: govuk-colour('black');
+
+      @media (forced-colors: active) {
+        background-color: linktext;
+      }
     }
   }
 }


### PR DESCRIPTION
# Added underline to sign out link when in high contrast mode

**Bug fix**

This adds an underline to the sign out link when in high contrast mode as reported at https://github.com/hmrc/design-patterns/issues/4#issuecomment-5330338227.

I've tested in Firefox on MacOS and Edge on Windows and the results are consistent and match the GOV.UK One Login Service Header behaviour.

Hover:
<img width="128" height="106" alt="Screenshot 2026-08-28 at 11 11 48" src="https://github.com/user-attachments/assets/2aced44e-6199-47a6-8945-6b1c116909fa" />

Focus:
<img width="128" height="106" alt="Screenshot 2026-08-28 at 11 11 44" src="https://github.com/user-attachments/assets/5aafd660-4c05-40c7-ad71-a5aa7941ca25" />

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
