### PR TITLE
PLATUI-4431 add npm audit exemptions

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -20,15 +20,21 @@
   "GHSA-mh99-v99m-4gvg": "brace-expansion: devDependency only, no risk given our usage",
   "GHSA-rgw5-rvv9-x895": "brace-expansion: devDependency only, no risk given our usage",
   "GHSA-q7cg-457f-vx79": "joi: uncaught RangeError on deeply nested input. devDependency only, pulled in via jest, no risk given our usage",
+  "GHSA-6w3j-5fw6-r9vr": "joi: Prototype pollution via a `__proto__` language key in custom messages. devDependency only, pulled in via jest, no risk given our usage",
+  "GHSA-gg4h-3hg2-grpc": "joi: object().rename() with a template target can set the validated object's prototype. devDependency only, pulled in via jest, no risk given our usage",
   "GHSA-96hv-2xvq-fx4p": "ws memory exhaustion DoS from tiny fragments and data chunks: pulled in via devDependency, no risk given our usage",
   "GHSA-h67p-54hq-rp68": "js-yaml: quadratic-complexity DoS in merge key: pulled in via devDependency, no risk given our usage",
   "GHSA-52cp-r559-cp3m": "js-yaml: merge-key chains: pulled in via devDependency, no risk given our usage",
   "GHSA-5p4m-2wfm-xmqj": "js-yaml: Quadratic CPU consumption in !!omap resolution: pulled in via devDependency, no risk given our usage",
+  "GHSA-2883-xcg3-v3hh": "js-yaml: maxTotalMergeKeys does not limit CPU use for empty merge sources: pulled in via devDependency, no risk given our usage",
   "GHSA-hmw2-7cc7-3qxx": "form-data: CRLF injection in form-data via unescaped multipart field names: pulled in via devDependency, no risk given our usage",
   "GHSA-4x5r-pxfx-6jf8": "babel/core: arbitrary file read via sourceMappingURL comment: devDependency only, no risk given our usage",
   "GHSA-xcpc-8h2w-3j85": "adm-zip: Crafted ZIP file triggers excessive memory allocation. devDependency only, no risk given our usage",
+  "GHSA-vwc7-r8mq-g2x9": "adm-zip: Extraction follows destination symlinks. devDependency only, no risk given our usage",
   "GHSA-v56q-mh7h-f735": "immutable: devDependency only, pulled in via sass, no risk given our usage",
   "GHSA-xvcm-6775-5m9r": "immutable: devDependency only, pulled in via sass, no risk given our usage",
   "GHSA-v422-hmwv-36x6": "body-parser: devDependency only, pulled in via sass, no risk given our usage",
-  "GHSA-jmr9-qjv8-65gv": "extract-zip: devDependency only, no risk given our usage"
+  "GHSA-jmr9-qjv8-65gv": "extract-zip: devDependency only, no risk given our usage",
+  "GHSA-7pqw-9j4j-h8q3": "extract-zip: allows arbitrary file writes through symlink archive entries. devDependency only, no risk given our usage",
+  "GHSA-2wm5-q62r-hmrv": "colord: slow rejection of oversized malformed colour strings. devDependency only, no risk given our usage"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [7.34.0] - 2026-09-10
+
+- Updated npm audit exclusions
+
 ## [7.33.0] - 2026-09-10
 
 - Uplifted `govuk-frontend` version to v6.5.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hmrc-frontend",
-  "version": "7.33.0",
+  "version": "7.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hmrc-frontend",
-      "version": "7.33.0",
+      "version": "7.34.0",
       "license": "Apache-2.0",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1",
@@ -15066,11 +15066,10 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
       }
@@ -16547,19 +16546,18 @@
       "dev": true
     },
     "node_modules/svgo": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
-      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.1.0.tgz",
+      "integrity": "sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
-        "css-select": "^5.1.0",
+        "css-select": "^6.0.0",
         "css-tree": "^3.0.1",
-        "css-what": "^6.1.0",
+        "css-what": "^7.0.0",
         "csso": "^5.0.5",
         "picocolors": "^1.1.1",
-        "sax": "^1.5.0"
+        "sax": "1.6.1"
       },
       "bin": {
         "svgo": "bin/svgo.js"
@@ -16580,6 +16578,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/svgo/node_modules/css-select": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
+      "integrity": "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^7.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "nth-check": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/svgo/node_modules/css-what": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
+      "integrity": "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmrc-frontend",
-  "version": "7.33.0",
+  "version": "7.34.0",
   "description": "Design patterns for HMRC frontends",
   "scripts": {
     "start": "gulp dev",
@@ -121,7 +121,7 @@
     "rollup": "$rollup",
     "tar": "^7.5.7",
     "tough-cookie": "^4.1.3",
-    "svgo": "^4.0.2",
+    "svgo": "^4.1.0",
     "browserslist": "^4.28.7",
     "postcss-selector-parser": "^7.1.3",
     "decode-uri-component": "0.5.0"


### PR DESCRIPTION
# Add npm audit exemptions

**Bug fix**

- Adds npm audit exemptions to address latest vulnerabilities

## Checklist

* [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guidance, including next steps and [expected response](../CONTRIBUTING.md#when-can-i-expect-someone-to-look-at-my-external-contribution) from the owners
* [x] I've added appropriate unit tests, and run all [unit tests](../CONTRIBUTING.md#unit-tests)
* [x] I've run the [visual regression test using Backstop](../CONTRIBUTING.md#visual-regression-tests) and updated the images if needed
* [x] I've run `npm version minor` to update the version in [package.json](../package.json) and [package-lock.json](../package-lock.json)
* [x] I've updated the [CHANGELOG](../CHANGELOG.md)
